### PR TITLE
cmd: add plugin execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@
 
 A client for managing [authzed] or any API-compatible system from your command line.
 
-**Note:** The master branch may be in an unstable or even broken state during development.
-Please use [releases] instead of the master branch in order to get stable binaries.
-
-[releases]: https://github.com/authzed/zed/releases
 [authzed]: https://authzed.com
+
+## Installation
+
+zed is currently packaged by as a _head-only_ [Homebrew] Formula for both macOS and Linux.
+
+[Homebrew]: https://brew.sh
+
+```sh
+$ brew install --HEAD authzed/tap/zed
+```
 
 ## Example Usage
 
@@ -31,12 +37,12 @@ API Tokens are stored in the system keychain.
 
 ```
 $ zed config set-token jimmy@authzed.com tu_zed_hanazawa_deadbeefdeadbeefdeadbeefdeadbeef
-NAME             	ENDPOINT            	TOKEN     	MODIFIED
-jimmy@authzed.com	grpc.authzed.com:443	<redacted>	now
+NAME             	ENDPOINT            	TOKEN
+jimmy@authzed.com	grpc.authzed.com:443	<redacted>
 
 $ zed config get-tokens
-NAME             	ENDPOINT            	TOKEN     	MODIFIED
-jimmy@authzed.com	grpc.authzed.com:443	<redacted>	2 minutes ago
+NAME             	ENDPOINT            	TOKEN
+jimmy@authzed.com	grpc.authzed.com:443	<redacted>
 ```
 
 Context data is stored in `$XDG_CONFIG_HOME/zed` falling back to `~/.zed` if that environment variable is not set.

--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -193,6 +193,21 @@ func main() {
 
 	rootCmd.AddCommand(deleteCmd)
 
+	plugins := []struct{ name, description string }{
+		{"testserver", "local testing server"},
+	}
+	for _, plugin := range plugins {
+		binaryName := fmt.Sprintf("zed-%s", plugin.name)
+		if commandIsAvailable(binaryName) {
+			rootCmd.AddCommand(&cobra.Command{
+				Use:                plugin.name,
+				Short:              plugin.description,
+				RunE:               pluginCmdFunc(binaryName),
+				DisableFlagParsing: true, // Passes flags as args to the subcommand.
+			})
+		}
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/zed/plugin.go
+++ b/cmd/zed/plugin.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+func commandIsAvailable(name string) bool {
+	return exec.Command("command", "-v", name).Run() == nil
+}
+
+func pluginCmdFunc(binaryName string) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		execCmd := exec.Command(binaryName, args...)
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+		return execCmd.Run()
+	}
+}


### PR DESCRIPTION
This will allow people with the zed-testserver binary installed to delegate commands to it with `zed testserver [args...] [flags...]`