### PR TITLE
fix(printers): print to target writer

### DIFF
--- a/internal/printers/table.go
+++ b/internal/printers/table.go
@@ -2,14 +2,13 @@ package printers
 
 import (
 	"io"
-	"os"
 
 	"github.com/olekukonko/tablewriter"
 )
 
 // PrintTable writes an terminal-friendly table of the values to the target.
 func PrintTable(target io.Writer, headers []string, rows [][]string) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(target)
 	table.SetHeader(headers)
 	table.SetAutoWrapText(false)
 	table.SetAutoFormatHeaders(true)


### PR DESCRIPTION
The `PrintTable` function ignores its `io.Writer` argument, always printing to `os.Stdout` instead.

Fix this by using the argument.

Addresses #21 