### PR TITLE
Find darwin release by glob

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,4 +111,4 @@ release:
   draft: true
   prerelease: "auto"
   extra_files:
-    - glob: "dist/zed_{{ .Version }}_darwin_amd64.tar.gz"
+    - glob: "**/*darwin*.tar.gz"


### PR DESCRIPTION
not clear why the previous wasn't finding it, goreleaser didn't have any logs related to extra_files