### PR TITLE
add head build to brew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,6 +92,9 @@ brews:
     test: |
       system "#{bin}/zed version"
     install: |
+      if !File.exists? "zed"
+        system "go build --ldflags \"-s -w -X github.com/authzed/zed/internal/version.Version=$(git describe --always --abbrev=7 --dirty)\" ./cmd/zed"
+      end
       bin.install "zed"
 
 checksum:


### PR DESCRIPTION
If a prebuilt `zed` can't be found, this will build from source.