### PR TITLE
Don't publish draft releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,7 +111,6 @@ changelog:
   sort: "asc"
 
 release:
-  draft: true
   prerelease: "auto"
   footer: |
     ## Docker Images


### PR DESCRIPTION
When the release is a draft, the homebrew tap is temporarily broken.

If we need to draft releases, we can use prerelease tags.