### PR TITLE
Relax automatic prefix handling to allow multiple prefixes

### DIFF
--- a/cmd/zed/schema.go
+++ b/cmd/zed/schema.go
@@ -272,6 +272,10 @@ func schemaCopyCmdFunc(cmd *cobra.Command, args []string) error {
 
 // rewriteSchema rewrites the given existing schema to include the specified prefix on all definitions.
 func rewriteSchema(existingSchemaText string, definitionPrefix string) (string, error) {
+	if definitionPrefix == "" {
+		return existingSchemaText, nil
+	}
+
 	nsDefs, err := compiler.Compile([]compiler.InputSchema{
 		{Source: input.Source("schema"), SchemaString: existingSchemaText},
 	}, &definitionPrefix)
@@ -353,15 +357,11 @@ func determinePrefixForSchema(specifiedPrefix string, client *authzed.Client, ex
 	}
 
 	prefixes := stringz.Dedup(foundPrefixes)
-	if len(prefixes) == 0 {
-		return "", fmt.Errorf("found no schema definition prefixes")
+	if len(prefixes) == 1 {
+		prefix := prefixes[0]
+		log.Debug().Str("prefix", prefix).Msg("found schema definition prefix")
+		return prefix, nil
 	}
 
-	if len(prefixes) > 1 {
-		return "", fmt.Errorf("found multiple schema definition prefixes: %v", prefixes)
-	}
-
-	prefix := prefixes[0]
-	log.Debug().Str("prefix", prefix).Msg("found schema definition prefix")
-	return prefix, nil
+	return "", nil
 }

--- a/cmd/zed/schema_test.go
+++ b/cmd/zed/schema_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeterminePrefixForSchema(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingSchema  string
+		specifiedPrefix string
+		expectedPrefix  string
+	}{
+		{
+			"empty schema",
+			"",
+			"",
+			"",
+		},
+		{
+			"no prefix, none specified",
+			`definition user {}`,
+			"",
+			"",
+		},
+		{
+			"no prefix, one specified",
+			`definition user {}`,
+			"test",
+			"test",
+		},
+		{
+			"prefix found",
+			`definition test/user {}`,
+			"",
+			"test",
+		},
+		{
+			"multiple prefixes found",
+			`definition test/user {}
+			
+			definition something/resource {}`,
+			"",
+			"",
+		},
+		{
+			"multiple prefixes found, one specified",
+			`definition test/user {}
+			
+			definition something/resource {}`,
+			"foobar",
+			"foobar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			found, err := determinePrefixForSchema(test.specifiedPrefix, nil, &test.existingSchema)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedPrefix, found)
+		})
+	}
+}
+
+func TestRewriteSchema(t *testing.T) {
+	tests := []struct {
+		name             string
+		existingSchema   string
+		definitionPrefix string
+		expectedSchema   string
+	}{
+		{
+			"empty schema",
+			"",
+			"",
+			"",
+		},
+		{
+			"empty prefix schema",
+			"definition user {}",
+			"",
+			"definition user {}",
+		},
+		{
+			"empty prefix schema with specified",
+			"definition user {}",
+			"test",
+			"definition test/user {}",
+		},
+		{
+			"prefixed schema with specified",
+			"definition foo/user {}",
+			"test",
+			"definition foo/user {}",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			found, err := rewriteSchema(test.existingSchema, test.definitionPrefix)
+			require.NoError(t, err)
+			require.Equal(t, test.expectedSchema, found)
+		})
+	}
+}


### PR DESCRIPTION
This was originally made strict before SpiceDB allowed multiple prefixes; now it is too strict

Fixes #131