### PR TITLE
add debug image variants

### DIFF
--- a/.goreleaser.docker.yml
+++ b/.goreleaser.docker.yml
@@ -30,8 +30,11 @@ builds:
     ldflags: *ldflags
 
 dockers:
+  # AMD64
   - image_templates:
-      - &amd_image "quay.io/authzed/zed:{{ .Version }}-amd64"
+      - &amd_image_quay "quay.io/authzed/zed:v{{ .Version }}-amd64"
+      - &amd_image_gh "ghcr.io/authzed/zed:v{{ .Version }}-amd64"
+      - &amd_image_dh "authzed/zed:v{{ .Version }}-amd64"
     ids: ["linux-amd64"]
     dockerfile: &dockerfile "Dockerfile.release"
     goos: "linux"
@@ -39,8 +42,24 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/amd64"
+  # AMD64 (debug)
   - image_templates:
-      - &arm_image "quay.io/authzed/zed:{{ .Version }}-arm64"
+      - &amd_debug_image_quay "quay.io/authzed/zed:v{{ .Version }}-amd64-debug"
+      - &amd_debug_image_gh "ghcr.io/authzed/zed:v{{ .Version }}-amd64-debug"
+      - &amd_debug_image_dh "authzed/zed:v{{ .Version }}-amd64-debug"
+    ids: ["linux-amd64"]
+    dockerfile: &dockerfile "Dockerfile.release"
+    goos: "linux"
+    goarch: "amd64"
+    use: "buildx"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=BASE=distroless.dev/busybox"
+  # ARM64
+  - image_templates:
+      - &arm_image_quay "quay.io/authzed/zed:v{{ .Version }}-arm64"
+      - &arm_image_gh "ghcr.io/authzed/zed:v{{ .Version }}-arm64"
+      - &arm_image_dh "authzed/zed:v{{ .Version }}-arm64"
     ids: ["linux-arm64"]
     dockerfile: *dockerfile
     goos: "linux"
@@ -48,16 +67,51 @@ dockers:
     use: "buildx"
     build_flag_templates:
       - "--platform=linux/arm64"
+  # ARM64 (debug)
+  - image_templates:
+      - &arm_debug_image_quay "quay.io/authzed/zed:v{{ .Version }}-arm64-debug"
+      - &arm_debug_image_gh "ghcr.io/authzed/zed:v{{ .Version }}-arm64-debug"
+      - &arm_debug_image_dh "authzed/zed:v{{ .Version }}-arm64-debug"
+    ids: ["linux-arm64"]
+    dockerfile: *dockerfile
+    goos: "linux"
+    goarch: "arm64"
+    use: "buildx"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=BASE=distroless.dev/busybox"
 
 docker_manifests:
-  - name_template: "quay.io/authzed/zed:{{ .Version }}"
-    image_templates:
-      - *amd_image
-      - *arm_image
+  # Quay
+  - name_template: "quay.io/authzed/zed:v{{ .Version }}"
+    image_templates: [*amd_image_quay, *arm_image_quay]
   - name_template: "quay.io/authzed/zed:latest"
-    image_templates:
-      - *amd_image
-      - *arm_image
-
+    image_templates: [*amd_image_quay, *arm_image_quay]
+  # GitHub Registry
+  - name_template: "ghcr.io/authzed/zed:v{{ .Version }}"
+    image_templates: [*amd_image_gh, *arm_image_gh]
+  - name_template: "ghcr.io/authzed/zed:latest"
+    image_templates: [*amd_image_gh, *arm_image_gh]
+  # Docker Hub
+  - name_template: "authzed/zed:v{{ .Version }}"
+    image_templates: [*amd_image_dh, *arm_image_dh]
+  - name_template: "authzed/zed:latest"
+    image_templates: [*amd_image_dh, *arm_image_dh]
+  # Debug Images:
+  # Quay (debug)
+  - name_template: "quay.io/authzed/zed:v{{ .Version }}-debug"
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
+  - name_template: "quay.io/authzed/zed:latest-debug"
+    image_templates: [*amd_debug_image_quay, *arm_debug_image_quay]
+  # GitHub Registry
+  - name_template: "ghcr.io/authzed/zed:v{{ .Version }}-debug"
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
+  - name_template: "ghcr.io/authzed/zed:latest-debug"
+    image_templates: [*amd_debug_image_gh, *arm_debug_image_gh]
+  # Docker Hub
+  - name_template: "authzed/zed:v{{ .Version }}-debug"
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
+  - name_template: "authzed/zed:latest-debug"
+    image_templates: [*amd_debug_image_dh, *arm_debug_image_dh]
 release:
   disable: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ COPY . /go/src/zed
 RUN go mod download
 RUN go install ./cmd/zed
 
-FROM gcr.io/distroless/base
+FROM distroless.dev/static
 COPY --from=build /go/bin/* /usr/local/bin/
 ENTRYPOINT ["zed"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,6 @@
 # vim: syntax=dockerfile
-FROM gcr.io/distroless/base
+ARG BASE=distroless.dev/static
+FROM $BASE
+
 COPY zed /usr/local/bin/zed
 ENTRYPOINT ["zed"]


### PR DESCRIPTION
Fixes https://github.com/authzed/zed/issues/141

I've basically ported changes in https://github.com/authzed/spicedb/pull/750

- I've also updated `Dockerfile` to use distroless.dev/static. The original PR did not update that file.
- I've noticed the `build` section of `.goreleaser.docker.yaml` deviates from the one in SpiceDB. I've left untouched, but wonder if we should align them