### PR TITLE
Fix broken release images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,10 +18,10 @@ jobs:
           echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.18"
-      - uses: "goreleaser/goreleaser-action@v2"
+          go-version: "~1.19"
+      - uses: "goreleaser/goreleaser-action@v3"
         with:
-          distribution: "goreleaser"
+          distribution: "goreleaser-pro"
           version: "latest"
           args: "release --rm-dist"
         env:
@@ -43,10 +43,10 @@ jobs:
         run: "sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu gcc-mingw-w64-x86-64"
       - uses: "actions/setup-go@v3"
         with:
-          go-version: "~1.19.1"
-      - uses: "goreleaser/goreleaser-action@v2"
+          go-version: "~1.19"
+      - uses: "goreleaser/goreleaser-action@v3"
         with:
-          distribution: "goreleaser"
+          distribution: "goreleaser-pro"
           version: "latest"
           args: "release --config=.goreleaser.docker.yml --rm-dist"
         env:

--- a/.goreleaser.docker.yml
+++ b/.goreleaser.docker.yml
@@ -3,9 +3,7 @@ builds:
   - id: "linux-amd64"
     goos: ["linux"]
     goarch: ["amd64"]
-    env:
-      - "CC=gcc"
-      - "CGO_ENABLED=1"
+    env: ["CC=gcc", "CGO_ENABLED=0"]
     main: &main "./cmd/zed"
     binary: &binary "zed"
     mod_timestamp: &mod_timestamp "{{ .CommitTimestamp }}"
@@ -18,9 +16,7 @@ builds:
   - id: "linux-arm64"
     goos: ["linux"]
     goarch: ["arm64"]
-    env:
-      - "CC=aarch64-linux-gnu-gcc"
-      - "CGO_ENABLED=1"
+    env: ["CC=aarch64-linux-gnu-gcc", "CGO_ENABLED=0"]
     main: *main
     binary: *binary
     mod_timestamp: *mod_timestamp

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,10 +157,10 @@ snapshot:
 
 changelog:
   use: "github-native"
+  sort: "asc"
 
 release:
   prerelease: "auto"
   footer: |
     ## Docker Images
-
-    This release is available at `quay.io/authzed/zed:v{{ .Version }}`
+    This release is available at `authzed/zed:v{{ .Version }}`, `quay.io/authzed/zed:v{{ .Version }}`, `ghcr.io/authzed/zed:v{{ .Version }}`


### PR DESCRIPTION
This disables CGO in release containers, which fixes the issue where the binary cannot be found.

Fixes #151 