### PR TITLE
Allow the use of custom CA Certificates

### DIFF
--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -51,16 +51,16 @@ func dialOptsFromFlags(cmd *cobra.Command, token storage.Token) []grpc.DialOptio
 		grpc.WithChainUnaryInterceptor(interceptors...),
 	}
 
-	if cobrautil.MustGetBool(cmd, "insecure") && cobrautil.MustGetString(cmd, "cacert") != "" {
+	if cobrautil.MustGetBool(cmd, "insecure") && cobrautil.MustGetString(cmd, "cafile") != "" {
 		panic("cafile flag cannot be combined with insecure")
 	}
 
 	if cobrautil.MustGetBool(cmd, "insecure") || (token.IsInsecure()) {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		opts = append(opts, grpcutil.WithInsecureBearerToken(token.APIToken))
-	} else if cobrautil.MustGetString(cmd, "cacert") != "" {
+	} else if cobrautil.MustGetString(cmd, "cafile") != "" {
 		opts = append(opts, grpcutil.WithBearerToken(token.APIToken))
-		opts = append(opts, grpcutil.WithCustomCerts(cobrautil.MustGetString(cmd, "cacert"), cobrautil.MustGetBool(cmd, "no-verify-ca")))
+		opts = append(opts, grpcutil.WithCustomCerts(cobrautil.MustGetString(cmd, "cafile"), cobrautil.MustGetBool(cmd, "no-verify-ca")))
 	} else {
 		opts = append(opts, grpcutil.WithBearerToken(token.APIToken))
 		opts = append(opts, grpcutil.WithSystemCerts(cobrautil.MustGetBool(cmd, "no-verify-ca")))
@@ -90,7 +90,7 @@ func main() {
 	rootCmd.PersistentFlags().Bool("insecure", false, "connect over a plaintext connection")
 	rootCmd.PersistentFlags().Bool("skip-version-check", false, "if true, no version check is performed against the server")
 	rootCmd.PersistentFlags().Bool("no-verify-ca", false, "do not attempt to verify the server's certificate chain and host name")
-	rootCmd.PersistentFlags().String("cacert", "", "Use the contents of file as a CA Trust Bundle (PEM-formatted DER)")
+	rootCmd.PersistentFlags().String("cafile", "", "Use the contents of file as a CA Trust Bundle (PEM-formatted DER)")
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
 

--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -51,9 +51,16 @@ func dialOptsFromFlags(cmd *cobra.Command, token storage.Token) []grpc.DialOptio
 		grpc.WithChainUnaryInterceptor(interceptors...),
 	}
 
+	if cobrautil.MustGetBool(cmd, "insecure") && cobrautil.MustGetString(cmd, "cacert") != "" {
+		panic("cafile flag cannot be combined with insecure")
+	}
+
 	if cobrautil.MustGetBool(cmd, "insecure") || (token.IsInsecure()) {
 		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		opts = append(opts, grpcutil.WithInsecureBearerToken(token.APIToken))
+	} else if cobrautil.MustGetString(cmd, "cacert") != "" {
+		opts = append(opts, grpcutil.WithBearerToken(token.APIToken))
+		opts = append(opts, grpcutil.WithCustomCerts(cobrautil.MustGetString(cmd, "cacert"), cobrautil.MustGetBool(cmd, "no-verify-ca")))
 	} else {
 		opts = append(opts, grpcutil.WithBearerToken(token.APIToken))
 		opts = append(opts, grpcutil.WithSystemCerts(cobrautil.MustGetBool(cmd, "no-verify-ca")))
@@ -83,6 +90,7 @@ func main() {
 	rootCmd.PersistentFlags().Bool("insecure", false, "connect over a plaintext connection")
 	rootCmd.PersistentFlags().Bool("skip-version-check", false, "if true, no version check is performed against the server")
 	rootCmd.PersistentFlags().Bool("no-verify-ca", false, "do not attempt to verify the server's certificate chain and host name")
+	rootCmd.PersistentFlags().String("cacert", "", "Use the contents of file as a CA Trust Bundle (PEM-formatted DER)")
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
 

--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -17,11 +17,11 @@ import (
 var ErrTokenNotFound = errors.New("token does not exist")
 
 type Token struct {
-	Name     string
-	Endpoint string
-	APIToken string
-	Insecure *bool
-	CAfile   []byte
+	Name        string
+	Endpoint    string
+	APIToken    string
+	Insecure    *bool
+	Certificate []byte
 }
 
 func (t Token) IsInsecure() bool {

--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -21,6 +21,7 @@ type Token struct {
 	Endpoint string
 	APIToken string
 	Insecure *bool
+	CAfile   []byte
 }
 
 func (t Token) IsInsecure() bool {


### PR DESCRIPTION
This allows the use of a custom CA Pool/[TrustBundle](https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/3257-trust-anchor-sets) via the `cafile` flag. Starts on #161, but does not support contexts, which would presumably want to embed the ca pool in the context secret.

The decision to use `cafile` for the flag name was based on `curl`, but kubectl calls it `--certificate-authority` and I've seen others. 