### PR TITLE
Call ResetFlags recursively to fix the reuse of the root command in WASM

### DIFF
--- a/pkg/wasm/main_test.go
+++ b/pkg/wasm/main_test.go
@@ -30,7 +30,14 @@ func TestZedCommand(t *testing.T) {
 	encodedContext, err := m.MarshalToString(requestCtx)
 	require.NoError(t, err)
 
-	result := runZedCommand(encodedContext, []string{"permission", "check", "document:firstdoc", "view", "user:tom"})
+	rootCmd := buildRootCmd()
+
+	// Run with --help
+	result := runZedCommand(rootCmd, encodedContext, []string{"permission", "check", "--help"})
+	require.Contains(t, result.Output, "Usage:")
+
+	// Run the actual command.
+	result = runZedCommand(rootCmd, encodedContext, []string{"permission", "check", "document:firstdoc", "view", "user:tom"})
 	require.Contains(t, result.Output, "false")
 
 	updatedContext := &devinterface.RequestContext{}


### PR DESCRIPTION
Without the `ResetFlags` call (recursively), calling a command with `--help` causes the flag to be "sticky" for all subsequent invocations

See: https://github.com/spf13/cobra/issues/1488