### PR TITLE
add caveat context to relationship read output

### DIFF
--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
@@ -236,13 +237,23 @@ func readRelationships(cmd *cobra.Command, args []string) error {
 
 			console.Println(string(prettyProto))
 		} else {
-			if msg.Relationship.Subject.OptionalRelation != "" {
-				console.Printf("%s:%s %s %s:%s#%s\n", msg.Relationship.Resource.ObjectType, msg.Relationship.Resource.ObjectId, msg.Relationship.Relation, msg.Relationship.Subject.Object.ObjectType, msg.Relationship.Subject.Object.ObjectId, msg.Relationship.Subject.OptionalRelation)
-			} else {
-				console.Printf("%s:%s %s %s:%s\n", msg.Relationship.Resource.ObjectType, msg.Relationship.Resource.ObjectId, msg.Relationship.Relation, msg.Relationship.Subject.Object.ObjectType, msg.Relationship.Subject.Object.ObjectId)
+			relString, err := relationshipToString(msg.Relationship)
+			if err != nil {
+				return err
 			}
+			console.Println(relString)
 		}
 	}
+}
+
+func relationshipToString(rel *v1.Relationship) (string, error) {
+	relString, err := tuple.StringRelationship(rel)
+	if err != nil {
+		return "", err
+	}
+	relString = strings.Replace(relString, "@", " ", 1)
+	relString = strings.Replace(relString, "#", " ", 1)
+	return relString, nil
 }
 
 func writeRelationshipCmdFunc(operation v1.RelationshipUpdate_Operation) func(cmd *cobra.Command, args []string) error {

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -21,12 +21,20 @@ func TestRelationshipToString(t *testing.T) {
 			"res:123 rel resource:1234",
 		},
 		{
+			"res:123#rel@resource:1234#anotherrel",
+			"res:123 rel resource:1234#anotherrel",
+		},
+		{
 			"res:123#rel@resource:1234[caveat_name]",
 			"res:123 rel resource:1234[caveat_name]",
 		},
 		{
 			"res:123#rel@resource:1234[caveat_name:{\"num\":1234}]",
 			"res:123 rel resource:1234[caveat_name:{\"num\":1234}]",
+		},
+		{
+			"res:123#rel@resource:1234[caveat_name:{\"name\":\"##@@##@@\"}]",
+			"res:123 rel resource:1234[caveat_name:{\"name\":\"##@@##@@\"}]",
 		},
 	} {
 		t.Run(tt.rawRel, func(t *testing.T) {

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -1,0 +1,39 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelationshipToString(t *testing.T) {
+	for _, tt := range []struct {
+		rawRel   string
+		expected string
+	}{
+		{
+			"prefix/res:123#rel@prefix/resource:1234",
+			"prefix/res:123 rel prefix/resource:1234",
+		},
+		{
+			"res:123#rel@resource:1234",
+			"res:123 rel resource:1234",
+		},
+		{
+			"res:123#rel@resource:1234[caveat_name]",
+			"res:123 rel resource:1234[caveat_name]",
+		},
+		{
+			"res:123#rel@resource:1234[caveat_name:{\"num\":1234}]",
+			"res:123 rel resource:1234[caveat_name:{\"num\":1234}]",
+		},
+	} {
+		t.Run(tt.rawRel, func(t *testing.T) {
+			rel := tuple.ParseRel(tt.rawRel)
+			out, err := relationshipToString(rel)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, out)
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/authzed/zed/issues/198

the `zed relationship read` command missed caveat context