### PR TITLE
internal/secrets: fix headless file keyring

### DIFF
--- a/cmd/zed/context.go
+++ b/cmd/zed/context.go
@@ -58,7 +58,7 @@ var contextUseCmd = &cobra.Command{
 	RunE:  contextUseCmdFunc,
 }
 
-func contextListCmdFunc(cmd *cobra.Command, args []string) error {
+func contextListCmdFunc(cmd *cobra.Command, _ []string) error {
 	cfgStore, secretStore := client.DefaultStorage()
 	secrets, err := secretStore.Get()
 	if err != nil {
@@ -81,7 +81,7 @@ func contextListCmdFunc(cmd *cobra.Command, args []string) error {
 			secret = token.Redacted()
 		}
 
-		certStr := ""
+		var certStr string
 		if token.IsInsecure() {
 			certStr = "insecure"
 		} else if _, ok := token.Certificate(); ok {
@@ -136,7 +136,7 @@ func contextSetCmdFunc(cmd *cobra.Command, args []string) error {
 	return storage.SetCurrentToken(name, cfgStore, secretStore)
 }
 
-func contextRemoveCmdFunc(cmd *cobra.Command, args []string) error {
+func contextRemoveCmdFunc(_ *cobra.Command, args []string) error {
 	// If the token is what's currently being used, remove it from the config.
 	cfgStore, secretStore := client.DefaultStorage()
 	cfg, err := cfgStore.Get()
@@ -156,7 +156,7 @@ func contextRemoveCmdFunc(cmd *cobra.Command, args []string) error {
 	return storage.RemoveToken(args[0], secretStore)
 }
 
-func contextUseCmdFunc(cmd *cobra.Command, args []string) error {
+func contextUseCmdFunc(_ *cobra.Command, args []string) error {
 	cfgStore, secretStore := client.DefaultStorage()
 	switch len(args) {
 	case 0:

--- a/cmd/zed/validate.go
+++ b/cmd/zed/validate.go
@@ -62,7 +62,7 @@ var validateCmd = &cobra.Command{
 	RunE: validateCmdFunc,
 }
 
-func validateCmdFunc(cmd *cobra.Command, args []string) error {
+func validateCmdFunc(_ *cobra.Command, args []string) error {
 	// Parse the URL of the validation document to import.
 	u, err := url.Parse(args[0])
 	if err != nil {

--- a/cmd/zed/version.go
+++ b/cmd/zed/version.go
@@ -20,7 +20,7 @@ import (
 	"github.com/authzed/zed/internal/storage"
 )
 
-func versionCmdFunc(cmd *cobra.Command, args []string) error {
+func versionCmdFunc(cmd *cobra.Command, _ []string) error {
 	if !term.IsTerminal(int(os.Stdout.Fd())) {
 		color.Disable()
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -64,7 +64,8 @@ func DefaultStorage() (storage.ConfigStore, storage.SecretStore) {
 		homedir, _ := homedir.Dir()
 		home = filepath.Join(homedir, ".zed")
 	}
-	return storage.JSONConfigStore{ConfigPath: home}, storage.KeychainSecretStore{ConfigPath: home}
+	return &storage.JSONConfigStore{ConfigPath: home},
+		&storage.KeychainSecretStore{ConfigPath: home}
 }
 
 func certOption(cmd *cobra.Command, token storage.Token) (opt grpc.DialOption, err error) {

--- a/internal/commands/schema.go
+++ b/internal/commands/schema.go
@@ -38,7 +38,7 @@ var (
 	}
 )
 
-func schemaReadCmdFunc(cmd *cobra.Command, args []string) error {
+func schemaReadCmdFunc(cmd *cobra.Command, _ []string) error {
 	client, err := client.NewClient(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit vastly improves the file keyring to
- only prompt once per execution
- specify when creating a password

Fixes #197