### PR TITLE
move code in cmd/zed to internal/cmd

### DIFF
--- a/cmd/zed/main.go
+++ b/cmd/zed/main.go
@@ -1,74 +1,7 @@
 package main
 
-import (
-	"os"
-
-	"github.com/jzelinskie/cobrautil/v2"
-	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
-	"github.com/rs/zerolog"
-	"github.com/spf13/cobra"
-
-	"github.com/authzed/zed/internal/commands"
-)
-
-var SyncFlagsCmdFunc = cobrautil.SyncViperPreRunE("ZED")
+import "github.com/authzed/zed/internal/cmd"
 
 func main() {
-	zl := cobrazerolog.New(cobrazerolog.WithPreRunLevel(zerolog.DebugLevel))
-
-	rootCmd := &cobra.Command{
-		Use:   "zed",
-		Short: "SpiceDB client, by AuthZed",
-		Long:  "A command-line client for managing SpiceDB clusters, built by AuthZed",
-		PersistentPreRunE: cobrautil.CommandStack(
-			zl.RunE(),
-			SyncFlagsCmdFunc,
-		),
-	}
-
-	zl.RegisterFlags(rootCmd.PersistentFlags())
-
-	rootCmd.PersistentFlags().String("endpoint", "", "spicedb gRPC API endpoint")
-	rootCmd.PersistentFlags().String("permissions-system", "", "permissions system to query")
-	rootCmd.PersistentFlags().String("token", "", "token used to authenticate to SpiceDB")
-	rootCmd.PersistentFlags().String("certificate-path", "", "path to certificate authoriy used to verify secure connections")
-	rootCmd.PersistentFlags().Bool("insecure", false, "connect over a plaintext connection")
-	rootCmd.PersistentFlags().Bool("skip-version-check", false, "if true, no version check is performed against the server")
-	rootCmd.PersistentFlags().Bool("no-verify-ca", false, "do not attempt to verify the server's certificate chain and host name")
-	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
-	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
-
-	versionCmd := &cobra.Command{
-		Use:   "version",
-		Short: "display zed version information",
-		RunE:  versionCmdFunc,
-	}
-	cobrautil.RegisterVersionFlags(versionCmd.Flags())
-	versionCmd.Flags().Bool("include-remote-version", true, "whether to display the version of Authzed or SpiceDB for the current context")
-	rootCmd.AddCommand(versionCmd)
-
-	// Register root-level aliases
-	rootCmd.AddCommand(&cobra.Command{
-		Use:   "use <context>",
-		Short: "an alias for `zed context use`",
-		Args:  cobra.MaximumNArgs(1),
-		RunE:  contextUseCmdFunc,
-	})
-
-	// Register CLI-only commands.
-	registerContextCmd(rootCmd)
-	registerImportCmd(rootCmd)
-	registerValidateCmd(rootCmd)
-
-	// Register shared commands.
-	commands.RegisterPermissionCmd(rootCmd)
-	commands.RegisterRelationshipCmd(rootCmd)
-	commands.RegisterWatchCmd(rootCmd)
-
-	schemaCmd := commands.RegisterSchemaCmd(rootCmd)
-	registerAdditionalSchemaCmds(schemaCmd)
-
-	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
-	}
+	cmd.Run()
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/jzelinskie/cobrautil/v2"
+	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+
+	"github.com/authzed/zed/internal/commands"
+)
+
+var SyncFlagsCmdFunc = cobrautil.SyncViperPreRunE("ZED")
+
+func Run() {
+	zl := cobrazerolog.New(cobrazerolog.WithPreRunLevel(zerolog.DebugLevel))
+
+	rootCmd := &cobra.Command{
+		Use:   "zed",
+		Short: "SpiceDB client, by AuthZed",
+		Long:  "A command-line client for managing SpiceDB clusters, built by AuthZed",
+		PersistentPreRunE: cobrautil.CommandStack(
+			zl.RunE(),
+			SyncFlagsCmdFunc,
+		),
+	}
+
+	zl.RegisterFlags(rootCmd.PersistentFlags())
+
+	rootCmd.PersistentFlags().String("endpoint", "", "spicedb gRPC API endpoint")
+	rootCmd.PersistentFlags().String("permissions-system", "", "permissions system to query")
+	rootCmd.PersistentFlags().String("token", "", "token used to authenticate to SpiceDB")
+	rootCmd.PersistentFlags().String("certificate-path", "", "path to certificate authoriy used to verify secure connections")
+	rootCmd.PersistentFlags().Bool("insecure", false, "connect over a plaintext connection")
+	rootCmd.PersistentFlags().Bool("skip-version-check", false, "if true, no version check is performed against the server")
+	rootCmd.PersistentFlags().Bool("no-verify-ca", false, "do not attempt to verify the server's certificate chain and host name")
+	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
+	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
+
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "display zed version information",
+		RunE:  versionCmdFunc,
+	}
+	cobrautil.RegisterVersionFlags(versionCmd.Flags())
+	versionCmd.Flags().Bool("include-remote-version", true, "whether to display the version of Authzed or SpiceDB for the current context")
+	rootCmd.AddCommand(versionCmd)
+
+	// Register root-level aliases
+	rootCmd.AddCommand(&cobra.Command{
+		Use:   "use <context>",
+		Short: "an alias for `zed context use`",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  contextUseCmdFunc,
+	})
+
+	// Register CLI-only commands.
+	registerContextCmd(rootCmd)
+	registerImportCmd(rootCmd)
+	registerValidateCmd(rootCmd)
+
+	// Register shared commands.
+	commands.RegisterPermissionCmd(rootCmd)
+	commands.RegisterRelationshipCmd(rootCmd)
+	commands.RegisterWatchCmd(rootCmd)
+
+	schemaCmd := commands.RegisterSchemaCmd(rootCmd)
+	registerAdditionalSchemaCmds(schemaCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"bufio"

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"testing"

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"context"


### PR DESCRIPTION
I was being unable to run tests or run zed from
my IDE of choice, with the following error:

```
go build ./cmd/zed/main.go
# command-line-arguments
cmd/zed/main.go:44:10: undefined: versionCmdFunc
cmd/zed/main.go:55:10: undefined: contextUseCmdFunc cmd/zed/main.go:59:2: undefined: registerContextCmd cmd/zed/main.go:60:2: undefined: registerImportCmd cmd/zed/main.go:61:2: undefined: registerValidateCmd cmd/zed/main.go:69:2: undefined: registerAdditionalSchemaCmds
``

the way the IDE configures the go toolchain would cause some methods to be undefined. While I understand this is specific to one IDE vendor, and that the code would also be effectively unexported in its current state, it did not seem unreasonable to move all this code to the internal package in line with the conventions used in authzed/spicedb.

This commit does not change the code, just moves it to internal, and extracts all code in main.go into its own file with a new exported `Run()` function