### PR TITLE
replaces cockroachdb treeprinter with github.com/xlab/treeprint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/authzed/grpcutil v0.0.0-20230109193425-40ce0530e048
 	github.com/authzed/spicedb v1.15.1-0.20221230180603-22b7de8eab7c
 	github.com/charmbracelet/lipgloss v0.6.0
-	github.com/cockroachdb/cockroach v20.1.17+incompatible
 	github.com/gookit/color v1.5.2
 	github.com/jzelinskie/cobrautil/v2 v2.0.0-20221215210038-3f120e7f595f
 	github.com/jzelinskie/stringz v0.0.1
@@ -20,6 +19,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.1
+	github.com/xlab/treeprint v1.2.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.4.0
 	google.golang.org/grpc v1.52.3

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20220112060539-c52dc94e7fbe h1:QQ3GSy+MqSHxm/d8nCtnAiZdYFd45cYZPs8vOOIYKfk=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20220330162227-eded343319d0 h1:MK/+hUKWd1o46LiZ/PK0GHUEYDmHVbxqW6WSJBh61c8=
-github.com/cockroachdb/cockroach v20.1.17+incompatible h1:K1cIUwI9CoGsv1OKbtmTRl9e3OC3H6xfwrvTh+RVku8=
-github.com/cockroachdb/cockroach v20.1.17+incompatible/go.mod h1:xeT/CQ0qZHangbYbWShlCGAx31aV4AjGswDUjhKS6HQ=
 github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
@@ -458,6 +456,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -56,6 +56,7 @@ func TestDeterminePrefixForSchema(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			found, err := determinePrefixForSchema(test.specifiedPrefix, nil, &test.existingSchema)
 			require.NoError(t, err)
@@ -105,6 +106,7 @@ caveat test/some_caveat(someCondition int) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
 			found, err := rewriteSchema(test.existingSchema, test.definitionPrefix)
 			require.NoError(t, err)

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -10,7 +10,6 @@ import (
 	"github.com/authzed/authzed-go/pkg/requestmeta"
 	"github.com/authzed/authzed-go/pkg/responsemeta"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
@@ -281,9 +280,9 @@ func expandCmdFunc(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	tp := treeprinter.New()
+	tp := printers.NewTreePrinter()
 	printers.TreeNodeTree(tp, resp.TreeRoot)
-	console.Println(tp.String())
+	tp.Print()
 
 	return nil
 }
@@ -471,10 +470,9 @@ func displayDebugInformationIfRequested(cmd *cobra.Command, trailerMD metadata.M
 		}
 
 		if cobrautil.MustGetBool(cmd, "explain") {
-			tp := treeprinter.New()
+			tp := printers.NewTreePrinter()
 			printers.DisplayCheckTrace(debugInfo.Check, tp, hasError)
-			console.Println()
-			console.Println(tp.String())
+			tp.Print()
 		}
 
 		if cobrautil.MustGetBool(cmd, "schema") {

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -37,6 +37,7 @@ func TestRelationshipToString(t *testing.T) {
 			"res:123 rel resource:1234[caveat_name:{\"name\":\"##@@##@@\"}]",
 		},
 	} {
+		tt := tt
 		t.Run(tt.rawRel, func(t *testing.T) {
 			rel := tuple.ParseRel(tt.rawRel)
 			out, err := relationshipToString(rel)

--- a/internal/decode/decoder_test.go
+++ b/internal/decode/decoder_test.go
@@ -119,6 +119,7 @@ func TestRewriteURL(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			rewriteURL(&tt.in)
 			require.EqualValues(t, tt.out, tt.in)

--- a/internal/grpcutil/batch_test.go
+++ b/internal/grpcutil/batch_test.go
@@ -57,6 +57,7 @@ func TestConcurrentBatchOrdering(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -123,6 +124,7 @@ func TestConcurrentBatch(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/internal/printers/debug.go
+++ b/internal/printers/debug.go
@@ -5,19 +5,17 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/authzed/spicedb/pkg/tuple"
-
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/gookit/color"
 )
 
 // DisplayCheckTrace prints out the check trace found in the given debug message.
-func DisplayCheckTrace(checkTrace *v1.CheckDebugTrace, tp treeprinter.Node, hasError bool) {
+func DisplayCheckTrace(checkTrace *v1.CheckDebugTrace, tp *TreePrinter, hasError bool) {
 	displayCheckTrace(checkTrace, tp, hasError, map[string]struct{}{})
 }
 
-func displayCheckTrace(checkTrace *v1.CheckDebugTrace, tp treeprinter.Node, hasError bool, encountered map[string]struct{}) {
+func displayCheckTrace(checkTrace *v1.CheckDebugTrace, tp *TreePrinter, hasError bool, encountered map[string]struct{}) {
 	red := color.FgRed.Render
 	green := color.FgGreen.Render
 	cyan := color.FgCyan.Render

--- a/internal/printers/tree.go
+++ b/internal/printers/tree.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 	"github.com/jzelinskie/stringz"
 )
 
@@ -26,7 +25,7 @@ func prettySubject(subj *v1.SubjectReference) string {
 
 // TreeNodeTree walks an Authzed Tree Node and creates corresponding nodes
 // for a treeprinter.
-func TreeNodeTree(tp treeprinter.Node, treeNode *v1.PermissionRelationshipTree) {
+func TreeNodeTree(tp *TreePrinter, treeNode *v1.PermissionRelationshipTree) {
 	if treeNode.ExpandedObject != nil {
 		tp = tp.Child(fmt.Sprintf(
 			"%s:%s->%s",

--- a/internal/printers/treeprinter.go
+++ b/internal/printers/treeprinter.go
@@ -1,0 +1,31 @@
+package printers
+
+import (
+	"github.com/authzed/zed/internal/console"
+
+	"github.com/xlab/treeprint"
+)
+
+type TreePrinter struct {
+	tree treeprint.Tree
+}
+
+func NewTreePrinter() *TreePrinter {
+	return &TreePrinter{}
+}
+
+func (tp *TreePrinter) Child(val string) *TreePrinter {
+	if tp.tree == nil {
+		tp.tree = treeprint.NewWithRoot(val)
+		return tp
+	}
+	return &TreePrinter{tree: tp.tree.AddBranch(val)}
+}
+
+func (tp *TreePrinter) Print() {
+	console.Println(tp.String())
+}
+
+func (tp *TreePrinter) String() string {
+	return tp.tree.String()
+}

--- a/internal/printers/treeprinter_test.go
+++ b/internal/printers/treeprinter_test.go
@@ -1,0 +1,20 @@
+package printers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTreePrinter(t *testing.T) {
+	tp := NewTreePrinter()
+	tp.Child("value")
+	require.Equal(t, "value\n", tp.String())
+
+	tp = NewTreePrinter()
+	tp = tp.Child("parent")
+	sib := tp.Child("child1")
+	sib.Child("grandchild")
+	tp.Child("child2")
+	require.Equal(t, "parent\n├── child1\n│   └── grandchild\n└── child2\n", tp.String())
+}


### PR DESCRIPTION
despite CRDB's treeprinter converting to Apache 2.0 after the Change Date, the community reported friction on adopting `zed` because automated tools would flag BSL incompatible with Apache 2.0.

This commit replaces cockroachdb treeprinter with
github.com/xlab/treeprint.

It's a mostly 1:1 migration, except due to the design choice to always create an implicit empty root node. I addressed that by removing that implicit root node after the tree is populated, as unfortunately the printer is unable to realize we are starting the print process from an intermediate node. To hide that complexity I wrapped it in our own type.