### PR TITLE
capture SIGINT and fail-fast

### DIFF
--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,7 @@ func TestDeterminePrefixForSchema(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			found, err := determinePrefixForSchema(test.specifiedPrefix, nil, &test.existingSchema)
+			found, err := determinePrefixForSchema(context.Background(), test.specifiedPrefix, nil, &test.existingSchema)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedPrefix, found)
 		})

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/url"
@@ -62,7 +61,7 @@ var validateCmd = &cobra.Command{
 	RunE: validateCmdFunc,
 }
 
-func validateCmdFunc(_ *cobra.Command, args []string) error {
+func validateCmdFunc(cmd *cobra.Command, args []string) error {
 	// Parse the URL of the validation document to import.
 	u, err := url.Parse(args[0])
 	if err != nil {
@@ -87,7 +86,7 @@ func validateCmdFunc(_ *cobra.Command, args []string) error {
 	}
 
 	// Create the development context.
-	ctx := context.Background()
+	ctx := cmd.Context()
 	tuples := make([]*core.RelationTuple, 0, len(parsed.Relationships.Relationships))
 	for _, rel := range parsed.Relationships.Relationships {
 		tuples = append(tuples, tuple.MustFromRelationship(rel))

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -66,7 +65,7 @@ func versionCmdFunc(cmd *cobra.Command, _ []string) error {
 		// the client being unable to connect, etc. We just treat all such cases as an unknown
 		// version.
 		var headerMD metadata.MD
-		_, _ = client.ReadSchema(context.Background(), &v1.ReadSchemaRequest{}, grpc.Header(&headerMD))
+		_, _ = client.ReadSchema(cmd.Context(), &v1.ReadSchemaRequest{}, grpc.Header(&headerMD))
 		version := headerMD.Get(string(responsemeta.ServerVersion))
 
 		blue := color.FgLightBlue.Render

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -191,7 +190,7 @@ func checkCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	log.Trace().Interface("request", request).Send()
 
-	ctx := context.Background()
+	ctx := cmd.Context()
 	if cobrautil.MustGetBool(cmd, "explain") || cobrautil.MustGetBool(cmd, "schema") {
 		log.Info().Msg("debugging requested on check")
 		ctx = requestmeta.AddRequestHeaders(ctx, requestmeta.RequestDebugInformation)
@@ -265,7 +264,7 @@ func expandCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	log.Trace().Interface("request", request).Send()
 
-	resp, err := client.ExpandPermissionTree(context.Background(), request)
+	resp, err := client.ExpandPermissionTree(cmd.Context(), request)
 	if err != nil {
 		return err
 	}
@@ -324,7 +323,7 @@ func lookupResourcesCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	log.Trace().Interface("request", request).Send()
 
-	respStream, err := client.LookupResources(context.Background(), request)
+	respStream, err := client.LookupResources(cmd.Context(), request)
 	if err != nil {
 		return err
 	}
@@ -389,7 +388,7 @@ func lookupSubjectsCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 	log.Trace().Interface("request", request).Send()
 
-	respStream, err := client.LookupSubjects(context.Background(), request)
+	respStream, err := client.LookupSubjects(cmd.Context(), request)
 	if err != nil {
 		return err
 	}

--- a/internal/commands/schema.go
+++ b/internal/commands/schema.go
@@ -46,7 +46,7 @@ func schemaReadCmdFunc(cmd *cobra.Command, _ []string) error {
 	request := &v1.ReadSchemaRequest{}
 	log.Trace().Interface("request", request).Msg("requesting schema read")
 
-	resp, err := client.ReadSchema(context.Background(), request)
+	resp, err := client.ReadSchema(cmd.Context(), request)
 	if err != nil {
 		return err
 	}
@@ -66,11 +66,11 @@ func schemaReadCmdFunc(cmd *cobra.Command, _ []string) error {
 }
 
 // ReadSchema calls read schema for the client and returns the schema found.
-func ReadSchema(client client.Client) (string, error) {
+func ReadSchema(ctx context.Context, client client.Client) (string, error) {
 	request := &v1.ReadSchemaRequest{}
 	log.Trace().Interface("request", request).Msg("requesting schema read")
 
-	resp, err := client.ReadSchema(context.Background(), request)
+	resp, err := client.ReadSchema(ctx, request)
 	if err != nil {
 		errStatus, ok := status.FromError(err)
 		if !ok || errStatus.Code() != codes.NotFound {

--- a/internal/grpcutil/grpcutil.go
+++ b/internal/grpcutil/grpcutil.go
@@ -43,7 +43,7 @@ func CheckServerVersion(
 	} else if len(version) == 1 {
 		currentVersion := version[0]
 
-		rctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		rctx, cancel := context.WithTimeout(ctx, time.Second*2)
 		defer cancel()
 
 		state, _, release, cerr := releases.CheckIsLatestVersion(rctx, func() (string, error) {

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -102,7 +102,10 @@ func resetSubCommandFlagValues(root *cobra.Command) {
 }
 
 func runZedCommand(rootCmd *cobra.Command, requestContextJSON string, stringParams []string) zedCommandResult {
-	ctx := context.Background()
+	ctx := rootCmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	// Decode the request context.
 	requestCtx := &devinterface.RequestContext{}


### PR DESCRIPTION
certain operations may take long to execute, e.g. `ReadRelationships` with a very wide relation. The current behaviour is to completely ignore process termination via something like Control+C, and zed will continue to block until `SIGKILL` or
the operation completes. It's a jarring experience.

This commit introduces a goroutine the listens to `SIGINT` and cancels the context, which is also now propagated via cobra. This makes the command-line seem responsive when the user terminates it.