### PR TITLE
Fix bug when writing schema supplied via stdin

### DIFF
--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -117,7 +117,7 @@ func schemaCopyCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func schemaWriteCmdFunc(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 && term.IsTerminal(int(os.Stdout.Fd())) {
+	if len(args) == 0 && term.IsTerminal(int(os.Stdin.Fd())) {
 		return fmt.Errorf("must provide file path or contents via stdin")
 	}
 


### PR DESCRIPTION
The check to make sure that stdin is not a terminal was actually checking stdout, meaning that you cannot actually send a schema via stdin. This commit fixes this check.

I noticed this when working on #263 .