### PR TITLE
fixes when STDIN input and CLI args are provided

### DIFF
--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -94,10 +94,7 @@ var bulkDeleteCmd = &cobra.Command{
 }
 
 func writeRelationshipsFromArgsOrStdin(cmd *cobra.Command, args []string) error {
-	if ok := isArgsViaFile(os.Stdin); ok {
-		if len(args) > 0 {
-			return fmt.Errorf("cannot provide input both via command-line args and stdin")
-		}
+	if ok := isArgsViaFile(os.Stdin) && len(args) == 0; ok {
 		return nil
 	}
 	return cobra.ExactArgs(3)(cmd, args)
@@ -402,7 +399,7 @@ var ErrExhaustedRelationships = errors.New("exhausted all relationships")
 func writeRelationshipCmdFunc(operation v1.RelationshipUpdate_Operation, input *os.File) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		parser := SliceRelationshipParser(args)
-		if isArgsViaFile(input) {
+		if isArgsViaFile(input) && len(args) == 0 {
 			parser = FileRelationshipParser(input)
 		}
 


### PR DESCRIPTION
a potentially common scenario is zed is being invoked from a shell script that is having its input piped, but zed itself is being provided with arguments as the result of parsing that input in the script. In such case arguments provided should take precedence to the STDIN, instead of erroring out