### PR TITLE
Add missing context token attributes

### DIFF
--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -49,10 +49,12 @@ func DefaultToken(overrideEndpoint, overrideAPIToken string, cs ConfigStore, ss 
 	}
 
 	return Token{
-		Name:     token.Name,
-		Endpoint: stringz.DefaultEmpty(overrideEndpoint, token.Endpoint),
-		APIToken: stringz.DefaultEmpty(overrideAPIToken, token.APIToken),
-		Insecure: token.Insecure,
+		Name:       token.Name,
+		Endpoint:   stringz.DefaultEmpty(overrideEndpoint, token.Endpoint),
+		APIToken:   stringz.DefaultEmpty(overrideAPIToken, token.APIToken),
+		Insecure:   token.Insecure,
+		NoVerifyCA: token.NoVerifyCA,
+		CACert:     token.CACert,
 	}, nil
 }
 


### PR DESCRIPTION
The context token supports NoVerifyCA and CACert. When it restored the values from a keychain it wasn't mapping the values from the token read to the token returned. This prevented zed client users from benefiting from stored --no-verify-ca and --certificate-path values.

With a simple addition the values are passed from context and they no longer need to be manually set on the command line.