### PR TITLE
restore: report error if one of the batches fail

### DIFF
--- a/internal/cmd/restore.go
+++ b/internal/cmd/restore.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -127,7 +128,8 @@ func restoreCmdFunc(cmd *cobra.Command, args []string) error {
 			if err := relationshipWriter.Send(&v1.BulkImportRelationshipsRequest{
 				Relationships: batch,
 			}); err != nil {
-				return fmt.Errorf("error sending batch to server: %w", err)
+				_, closeErr := relationshipWriter.CloseAndRecv()
+				return fmt.Errorf("error sending batch to server: %w", errors.Join(err, closeErr))
 			}
 
 			// Reset the relationships in the batch


### PR DESCRIPTION
If one of the batches sent fails, zed will hide the underlying error and just report `EOF`.

The gRPC backend will report EOF as part of an error, which will have to be retrieved via `CloseAndRecv()`.

A common error that surfaced as EOF was duplicate relationships after reimporting the same backup file.