### PR TITLE
Add command for redacting backups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/olekukonko/tablewriter v0.0.5
+	github.com/rodaine/table v1.1.0
 	github.com/rs/zerolog v1.31.0
 	github.com/samber/lo v1.38.1
 	github.com/schollz/progressbar/v3 v3.14.1

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github/v43 v43.0.0 h1:y+GL7LIsAIF2NZlJ46ZoC/D1W1ivZasT0lnWHMYPZ+U=
@@ -542,6 +543,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rodaine/table v1.1.0 h1:/fUlCSdjamMY8VifdQRIu3VWZXYLY7QHFkVorS8NTr4=
+github.com/rodaine/table v1.1.0/go.mod h1:Qu3q5wi1jTQD6B6HsP6szie/S4w1QUQ8pq22pz9iL8g=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=

--- a/pkg/backupformat/redaction.go
+++ b/pkg/backupformat/redaction.go
@@ -1,0 +1,324 @@
+package backupformat
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/namespace"
+	core "github.com/authzed/spicedb/pkg/proto/core/v1"
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/schemadsl/generator"
+	"github.com/authzed/spicedb/pkg/schemadsl/input"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
+)
+
+// RedactionOptions are the options to use when redacting data.
+type RedactionOptions struct {
+	// RedactDefinitions will redact the definition names.
+	RedactDefinitions bool
+
+	// RedactRelations will redact the relation names.
+	RedactRelations bool
+
+	// RedactObjectIDs will redact the object IDs.
+	RedactObjectIDs bool
+}
+
+// RedactionMap is the map of original names to their redacted names.
+type RedactionMap struct {
+	// Definitions is the map of original definition names to their redacted names.
+	Definitions map[string]string
+
+	// Caveats is the map of original caveat names to their redacted names.
+	Caveats map[string]string
+
+	// Relations is the map of original relation names to their redacted names.
+	Relations map[string]string
+
+	// ObjectIDs is the map of original object IDs to their redacted names.
+	ObjectIDs map[string]string
+}
+
+// Invert returns the inverted redaction map, with the redacted names as the keys.
+func (rm RedactionMap) Invert() RedactionMap {
+	inverted := RedactionMap{
+		Definitions: make(map[string]string),
+		Caveats:     make(map[string]string),
+		Relations:   make(map[string]string),
+		ObjectIDs:   make(map[string]string),
+	}
+
+	for k, v := range rm.Definitions {
+		inverted.Definitions[v] = k
+	}
+
+	for k, v := range rm.Caveats {
+		inverted.Caveats[v] = k
+	}
+
+	for k, v := range rm.Relations {
+		inverted.Relations[v] = k
+	}
+
+	for k, v := range rm.ObjectIDs {
+		inverted.ObjectIDs[v] = k
+	}
+
+	return inverted
+}
+
+// NewRedactor creates a new redactor that will redact the data as it is written.
+func NewRedactor(dec *Decoder, w io.Writer, opts RedactionOptions) (*Redactor, error) {
+	// Rewrite the schema to redact as requested.
+	redactedSchema, redactionMap, err := redactSchema(dec.Schema(), opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new encoder with the redacted schema.
+	token := dec.ZedToken()
+	encoder, err := NewEncoder(w, redactedSchema, token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Redactor{dec, opts, encoder, redactionMap}, nil
+}
+
+type Redactor struct {
+	dec          *Decoder
+	opts         RedactionOptions
+	enc          *Encoder
+	redactionMap RedactionMap
+}
+
+// Next redacts the next record and writes it to the writer.
+func (r *Redactor) Next() error {
+	// Read the next record.
+	rel, err := r.dec.Next()
+	if err != nil {
+		return err
+	}
+
+	if rel == nil {
+		return io.EOF
+	}
+
+	// Redact the record.
+	redactedRel, err := redactRelationship(rel, &r.redactionMap, r.opts)
+	if err != nil {
+		return err
+	}
+
+	// Write the redacted record.
+	return r.enc.Append(redactedRel)
+}
+
+// RedactionMap returns the redaction map containing the original names and their redacted names.
+func (r *Redactor) RedactionMap() RedactionMap {
+	return r.redactionMap
+}
+
+func (r *Redactor) Close() error {
+	if err := r.enc.Close(); err != nil {
+		return err
+	}
+
+	return r.dec.Close()
+}
+
+func redactSchema(schema string, opts RedactionOptions) (string, RedactionMap, error) {
+	// Parse the schema.
+	compiled, err := compiler.Compile(compiler.InputSchema{
+		Source: input.Source("schema"), SchemaString: schema,
+	})
+	if err != nil {
+		return "", RedactionMap{}, err
+	}
+
+	// Create a new schema with the redacted fields.
+	redactionMap := RedactionMap{
+		Definitions: make(map[string]string),
+		Caveats:     make(map[string]string),
+		Relations:   make(map[string]string),
+		ObjectIDs:   make(map[string]string),
+	}
+
+	redactionCount := 0
+
+	// Redact namespace and caveat names.
+	if opts.RedactDefinitions {
+		for _, nsDef := range compiled.ObjectDefinitions {
+			if opts.RedactDefinitions {
+				redactionMap.Definitions[nsDef.Name] = "def" + strconv.Itoa(redactionCount)
+				redactionCount++
+				nsDef.Name = redactionMap.Definitions[nsDef.Name]
+			}
+
+			namespace.FilterUserDefinedMetadataInPlace(nsDef)
+		}
+
+		if len(compiled.CaveatDefinitions) > 0 {
+			fmt.Println("WARNING: Caveat parameters and comments are not currently redacted.")
+		}
+
+		for _, caveatDef := range compiled.CaveatDefinitions {
+			if opts.RedactDefinitions {
+				redactionMap.Caveats[caveatDef.Name] = "cav" + strconv.Itoa(redactionCount)
+				redactionCount++
+				caveatDef.Name = redactionMap.Caveats[caveatDef.Name]
+			}
+
+			// TODO: Redact caveat parameters.
+			// TODO: filter caveat metadata.
+		}
+	}
+
+	// Redact relation names.
+	if opts.RedactRelations {
+		for _, nsDef := range compiled.ObjectDefinitions {
+			for _, relDef := range nsDef.Relation {
+				if existing, ok := redactionMap.Relations[relDef.Name]; ok {
+					relDef.Name = existing
+					continue
+				}
+
+				redactionMap.Relations[relDef.Name] = "rel" + strconv.Itoa(redactionCount)
+				redactionCount++
+				relDef.Name = redactionMap.Relations[relDef.Name]
+			}
+		}
+	}
+
+	// Redact type information.
+	if opts.RedactDefinitions || opts.RedactRelations {
+		for _, nsDef := range compiled.ObjectDefinitions {
+			for _, relDef := range nsDef.Relation {
+				if relDef.TypeInformation != nil {
+					for _, allowedDirect := range relDef.TypeInformation.AllowedDirectRelations {
+						if opts.RedactDefinitions {
+							allowedDirect.Namespace = redactionMap.Definitions[allowedDirect.Namespace]
+
+							if allowedDirect.RequiredCaveat != nil {
+								allowedDirect.RequiredCaveat.CaveatName = redactionMap.Caveats[allowedDirect.RequiredCaveat.CaveatName]
+							}
+						}
+
+						if opts.RedactRelations {
+							switch t := allowedDirect.RelationOrWildcard.(type) {
+							case *core.AllowedRelation_Relation:
+								t.Relation = redactionMap.Relations[t.Relation]
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Redact within userset rewrites.
+	if opts.RedactRelations {
+		for _, nsDef := range compiled.ObjectDefinitions {
+			for _, relDef := range nsDef.Relation {
+				if relDef.UsersetRewrite != nil {
+					err := redactUsersetRewrite(relDef.UsersetRewrite, &redactionMap)
+					if err != nil {
+						return "", RedactionMap{}, err
+					}
+				}
+			}
+		}
+	}
+
+	// Generate the schema string.
+	generated, _, err := generator.GenerateSchema(compiled.OrderedDefinitions)
+	return generated, redactionMap, err
+}
+
+func redactUsersetRewrite(usersetRewrite *core.UsersetRewrite, redactionMap *RedactionMap) error {
+	switch t := usersetRewrite.RewriteOperation.(type) {
+	case *core.UsersetRewrite_Union:
+		return redactRewriteChildren(t.Union.Child, redactionMap)
+
+	case *core.UsersetRewrite_Intersection:
+		return redactRewriteChildren(t.Intersection.Child, redactionMap)
+
+	case *core.UsersetRewrite_Exclusion:
+		return redactRewriteChildren(t.Exclusion.Child, redactionMap)
+
+	default:
+		return spiceerrors.MustBugf("unknown userset rewrite type: %T", t)
+	}
+}
+
+func redactRewriteChildren(children []*core.SetOperation_Child, redactionMap *RedactionMap) error {
+	for _, child := range children {
+		switch t := child.ChildType.(type) {
+		case *core.SetOperation_Child_ComputedUserset:
+			t.ComputedUserset.Relation = redactionMap.Relations[t.ComputedUserset.Relation]
+
+		case *core.SetOperation_Child_UsersetRewrite:
+			err := redactUsersetRewrite(t.UsersetRewrite, redactionMap)
+			if err != nil {
+				return err
+			}
+
+		case *core.SetOperation_Child_TupleToUserset:
+			t.TupleToUserset.Tupleset.Relation = redactionMap.Relations[t.TupleToUserset.Tupleset.Relation]
+			t.TupleToUserset.ComputedUserset.Relation = redactionMap.Relations[t.TupleToUserset.ComputedUserset.Relation]
+
+		case *core.SetOperation_Child_XNil:
+			// nothing to do
+
+		case *core.SetOperation_Child_XThis:
+			// nothing to do
+
+		default:
+			return spiceerrors.MustBugf("unknown child type: %T", t)
+		}
+	}
+
+	return nil
+}
+
+func redactRelationship(rel *v1.Relationship, redactionMap *RedactionMap, opts RedactionOptions) (*v1.Relationship, error) {
+	redactedRel := rel.CloneVT()
+
+	// Redact the resource.
+	if opts.RedactDefinitions {
+		redactedRel.Resource.ObjectType = redactionMap.Definitions[redactedRel.Resource.ObjectType]
+		redactedRel.Subject.Object.ObjectType = redactionMap.Definitions[redactedRel.Subject.Object.ObjectType]
+
+		if rel.OptionalCaveat != nil {
+			redactedRel.OptionalCaveat.CaveatName = redactionMap.Caveats[redactedRel.OptionalCaveat.CaveatName]
+		}
+	}
+
+	// Redact the relation.
+	if opts.RedactRelations {
+		redactedRel.Relation = redactionMap.Relations[redactedRel.Relation]
+
+		if rel.Subject.OptionalRelation != "" {
+			redactedRel.Subject.OptionalRelation = redactionMap.Relations[redactedRel.Subject.OptionalRelation]
+		}
+	}
+
+	// Redact the object IDs.
+	if opts.RedactObjectIDs {
+		if _, ok := redactionMap.ObjectIDs[redactedRel.Resource.ObjectId]; !ok {
+			redactionMap.ObjectIDs[redactedRel.Resource.ObjectId] = "obj" + strconv.Itoa(len(redactionMap.ObjectIDs))
+		}
+
+		redactedRel.Resource.ObjectId = redactionMap.ObjectIDs[redactedRel.Resource.ObjectId]
+
+		if _, ok := redactionMap.ObjectIDs[redactedRel.Subject.Object.ObjectId]; !ok {
+			redactionMap.ObjectIDs[redactedRel.Subject.Object.ObjectId] = "obj" + strconv.Itoa(len(redactionMap.ObjectIDs))
+		}
+
+		redactedRel.Subject.Object.ObjectId = redactionMap.ObjectIDs[redactedRel.Subject.Object.ObjectId]
+	}
+
+	return redactedRel, nil
+}

--- a/pkg/backupformat/redaction_test.go
+++ b/pkg/backupformat/redaction_test.go
@@ -1,0 +1,385 @@
+package backupformat
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"testing"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/brianvoe/gofakeit/v6"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactSchema(t *testing.T) {
+	tcs := []struct {
+		name         string
+		opts         RedactionOptions
+		in           string
+		out          string
+		redactionMap RedactionMap
+	}{
+		{
+			name: "single def",
+			opts: RedactionOptions{
+				RedactDefinitions: true,
+				RedactRelations:   true,
+				RedactObjectIDs:   true,
+			},
+			in:  `definition user {}`,
+			out: `definition def0 {}`,
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{
+					"user": "def0",
+				},
+				Caveats:   map[string]string{},
+				Relations: map[string]string{},
+				ObjectIDs: map[string]string{},
+			},
+		},
+		{
+			name: "basic with relations",
+			opts: RedactionOptions{
+				RedactDefinitions: true,
+				RedactRelations:   true,
+				RedactObjectIDs:   true,
+			},
+			in: `
+			definition user {}
+
+			definition resource {
+				relation viewer: user
+				permission view = viewer
+			}`,
+			out: "definition def0 {}\n\ndefinition def1 {\n\trelation rel2: def0\n\tpermission rel3 = rel2\n}",
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{
+					"user":     "def0",
+					"resource": "def1",
+				},
+				Caveats: map[string]string{},
+				Relations: map[string]string{
+					"view":   "rel3",
+					"viewer": "rel2",
+				},
+				ObjectIDs: map[string]string{},
+			},
+		},
+		{
+			name: "no relation rewriting",
+			opts: RedactionOptions{
+				RedactDefinitions: true,
+				RedactRelations:   false,
+				RedactObjectIDs:   true,
+			},
+			in: `
+			definition user {}
+
+			definition resource {
+				relation viewer: user
+				permission view = viewer
+			}`,
+			out: "definition def0 {}\n\ndefinition def1 {\n\trelation viewer: def0\n\tpermission view = viewer\n}",
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{
+					"user":     "def0",
+					"resource": "def1",
+				},
+				Caveats:   map[string]string{},
+				Relations: map[string]string{},
+				ObjectIDs: map[string]string{},
+			},
+		},
+		{
+			name: "no definition rewriting",
+			opts: RedactionOptions{
+				RedactDefinitions: false,
+				RedactRelations:   true,
+				RedactObjectIDs:   true,
+			},
+			in: `
+			definition user {}
+
+			definition resource {
+				relation viewer: user
+				permission view = viewer
+			}`,
+			out: "definition user {}\n\ndefinition resource {\n\trelation rel0: user\n\tpermission rel1 = rel0\n}",
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{},
+				Caveats:     map[string]string{},
+				Relations: map[string]string{
+					"view":   "rel1",
+					"viewer": "rel0",
+				},
+				ObjectIDs: map[string]string{},
+			},
+		},
+		{
+			name: "basic with caveats",
+			opts: RedactionOptions{
+				RedactDefinitions: true,
+				RedactRelations:   true,
+				RedactObjectIDs:   true,
+			},
+			in: `
+			definition user {}
+
+			caveat some_caveat(is_allowed bool) {
+				is_allowed
+			}
+
+			definition resource {
+				relation viewer: user with some_caveat
+				permission view = viewer
+			}`,
+			out: "definition def0 {}\n\ncaveat cav2(is_allowed bool) {\n\tis_allowed\n}\n\ndefinition def1 {\n\trelation rel3: def0 with cav2\n\tpermission rel4 = rel3\n}",
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{
+					"user":     "def0",
+					"resource": "def1",
+				},
+				Caveats: map[string]string{
+					"some_caveat": "cav2",
+				},
+				Relations: map[string]string{
+					"view":   "rel4",
+					"viewer": "rel3",
+				},
+				ObjectIDs: map[string]string{},
+			},
+		},
+		{
+			name: "all expressions",
+			opts: RedactionOptions{
+				RedactDefinitions: true,
+				RedactRelations:   true,
+				RedactObjectIDs:   true,
+			},
+			in: `
+			definition user {}
+
+			definition resource {
+				relation viewer: user
+				relation editor: user
+
+				permission somethingelse = viewer->editor + nil
+				permission view = viewer & (viewer - editor)
+			}`,
+			out: "definition def0 {}\n\ndefinition def1 {\n\trelation rel2: def0\n\trelation rel3: def0\n\tpermission rel4 = rel2->rel3 + nil\n\tpermission rel5 = rel2 & (rel2 - rel3)\n}",
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{
+					"user":     "def0",
+					"resource": "def1",
+				},
+				Caveats: map[string]string{},
+				Relations: map[string]string{
+					"editor":        "rel3",
+					"somethingelse": "rel4",
+					"view":          "rel5",
+					"viewer":        "rel2",
+				},
+				ObjectIDs: map[string]string{},
+			},
+		},
+		{
+			name: "all types",
+			opts: RedactionOptions{
+				RedactDefinitions: true,
+				RedactRelations:   true,
+				RedactObjectIDs:   true,
+			},
+			in: `
+			definition user {}
+
+			definition someothertype {
+				relation somerel: user
+			}
+
+			definition resource {
+				relation viewer: user | user:* | someothertype#somerel
+			}`,
+			out: "definition def0 {}\n\ndefinition def1 {\n\trelation rel3: def0\n}\n\ndefinition def2 {\n\trelation rel4: def0 | def0:* | def1#rel3\n}",
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{
+					"user":          "def0",
+					"someothertype": "def1",
+					"resource":      "def2",
+				},
+				Caveats: map[string]string{},
+				Relations: map[string]string{
+					"somerel": "rel3",
+					"viewer":  "rel4",
+				},
+				ObjectIDs: map[string]string{},
+			},
+		},
+		{
+			name: "same relation name in different definitions",
+			opts: RedactionOptions{
+				RedactDefinitions: true,
+				RedactRelations:   true,
+				RedactObjectIDs:   true,
+			},
+			in: `
+			definition user {}
+
+			definition someothertype {
+				relation somerel: user
+			}
+			
+			definition resource {
+				relation somerel: user
+			}`,
+			out: "definition def0 {}\n\ndefinition def1 {\n\trelation rel3: def0\n}\n\ndefinition def2 {\n\trelation rel3: def0\n}",
+			redactionMap: RedactionMap{
+				Definitions: map[string]string{
+					"user":          "def0",
+					"someothertype": "def1",
+					"resource":      "def2",
+				},
+				Caveats: map[string]string{},
+				Relations: map[string]string{
+					"somerel": "rel3",
+				},
+				ObjectIDs: map[string]string{},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			out, redactionMap, err := redactSchema(tc.in, tc.opts)
+			require.NoError(t, err)
+			require.Equal(t, tc.out, out)
+			require.Equal(t, tc.redactionMap, redactionMap)
+		})
+	}
+}
+
+func TestRedactBackup(t *testing.T) {
+	exampleSchema := `
+	definition user {}
+
+	definition someotheresource {
+		relation foo: user
+	}
+
+	definition resource {
+		relation viewer: user
+		permission view = viewer
+	}`
+
+	exampleRelationships := []*v1.Relationship{
+		{
+			Resource: &v1.ObjectReference{
+				ObjectType: "resource",
+				ObjectId:   "resource1",
+			},
+			Relation: "viewer",
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: "user",
+					ObjectId:   "user1",
+				},
+			},
+		},
+		{
+			Resource: &v1.ObjectReference{
+				ObjectType: "resource",
+				ObjectId:   "resource2",
+			},
+			Relation: "viewer",
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: "user",
+					ObjectId:   "user2",
+				},
+			},
+		},
+		{
+			Resource: &v1.ObjectReference{
+				ObjectType: "resource",
+				ObjectId:   "resource1",
+			},
+			Relation: "viewer",
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: "user",
+					ObjectId:   "user2",
+				},
+			},
+		},
+		{
+			Resource: &v1.ObjectReference{
+				ObjectType: "someotheresource",
+				ObjectId:   "resource1",
+			},
+			Relation: "foo",
+			Subject: &v1.SubjectReference{
+				Object: &v1.ObjectReference{
+					ObjectType: "user",
+					ObjectId:   "user1",
+				},
+			},
+		},
+	}
+
+	// Write some data.
+	buf := bytes.Buffer{}
+	enc, err := NewEncoder(&buf, exampleSchema, &v1.ZedToken{
+		Token: base64.StdEncoding.EncodeToString(gofakeit.ImageJpeg(10, 10)),
+	})
+	require.NoError(t, err)
+
+	for _, rel := range exampleRelationships {
+		require.NoError(t, enc.Append(rel))
+	}
+	require.NoError(t, enc.Close())
+	require.NotEmpty(t, buf.Bytes())
+
+	// Redact it into a new buffer.
+	redactedBuf := bytes.Buffer{}
+
+	decoder, err := NewDecoder(bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+
+	r, err := NewRedactor(decoder, &redactedBuf, RedactionOptions{
+		RedactDefinitions: true,
+		RedactRelations:   true,
+		RedactObjectIDs:   true,
+	})
+	require.NoError(t, err)
+
+	for {
+		err := r.Next()
+		if err != nil {
+			require.Equal(t, io.EOF, err)
+			break
+		}
+	}
+
+	require.NoError(t, r.Close())
+
+	redactionMap := r.RedactionMap().Invert()
+
+	// Validate the redacted data.
+	redactedDecoder, err := NewDecoder(bytes.NewReader(redactedBuf.Bytes()))
+	require.NoError(t, err)
+
+	require.Equal(t, "definition def0 {}\n\ndefinition def1 {\n\trelation rel3: def0\n}\n\ndefinition def2 {\n\trelation rel4: def0\n\tpermission rel5 = rel4\n}", redactedDecoder.Schema())
+	require.Equal(t, decoder.ZedToken(), redactedDecoder.ZedToken())
+
+	for _, expected := range exampleRelationships {
+		rel, err := redactedDecoder.Next()
+		require.NoError(t, err)
+
+		// Validate the redacted relationship.
+		require.Equal(t, expected.Resource.ObjectType, redactionMap.Definitions[rel.Resource.ObjectType])
+		require.Equal(t, expected.Resource.ObjectId, redactionMap.ObjectIDs[rel.Resource.ObjectId])
+		require.Equal(t, expected.Relation, redactionMap.Relations[rel.Relation])
+		require.Equal(t, expected.Subject.Object.ObjectType, redactionMap.Definitions[rel.Subject.Object.ObjectType])
+		require.Equal(t, expected.Subject.Object.ObjectId, redactionMap.ObjectIDs[rel.Subject.Object.ObjectId])
+		require.Equal(t, expected.Subject.OptionalRelation, redactionMap.Relations[rel.Subject.OptionalRelation])
+	}
+}


### PR DESCRIPTION
Helpful for providing community support without leaking the names, comments and/or object IDs in the permission system

Related: #194