### PR TITLE
More and less completion

### DIFF
--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -32,7 +32,7 @@ import (
 var (
 	backupCmd = &cobra.Command{
 		Use:   "backup <filename>",
-		Short: "Create, restore, and inspect Permissions System backups",
+		Short: "Create, restore, and inspect permissions system backups",
 		Args:  cobra.ExactArgs(1),
 		// Create used to be on the root, so add it here for back-compat.
 		RunE: backupCreateCmdFunc,
@@ -107,7 +107,7 @@ func registerBackupCmd(rootCmd *cobra.Command) {
 	// Restore used to be on the root, so add it there too, but hidden.
 	restoreCmd := &cobra.Command{
 		Use:    "restore <filename>",
-		Short:  "Restore a permission system from a file",
+		Short:  "Restore a permission system from a backup file",
 		Args:   cobra.MaximumNArgs(1),
 		RunE:   backupRestoreCmdFunc,
 		Hidden: true,

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -55,7 +55,7 @@ func Run() {
 
 	versionCmd := &cobra.Command{
 		Use:   "version",
-		Short: "display zed version information",
+		Short: "Display zed and SpiceDB version information",
 		RunE:  versionCmdFunc,
 	}
 	cobrautil.RegisterVersionFlags(versionCmd.Flags())
@@ -65,7 +65,7 @@ func Run() {
 	// Register root-level aliases
 	rootCmd.AddCommand(&cobra.Command{
 		Use:               "use <context>",
-		Short:             "an alias for `zed context use`",
+		Short:             "Alias for `zed context use`",
 		Args:              cobra.MaximumNArgs(1),
 		RunE:              contextUseCmdFunc,
 		ValidArgsFunction: ContextGet,

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -27,12 +27,12 @@ func registerContextCmd(rootCmd *cobra.Command) {
 
 var contextCmd = &cobra.Command{
 	Use:   "context <subcommand>",
-	Short: "manage your machines Authzed credentials",
+	Short: "Manage configurations for connecting to SpiceDB deployments",
 }
 
 var contextListCmd = &cobra.Command{
 	Use:               "list",
-	Short:             "list all contexts",
+	Short:             "Lists all available contexts",
 	Args:              cobra.ExactArgs(0),
 	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE:              contextListCmdFunc,
@@ -40,7 +40,7 @@ var contextListCmd = &cobra.Command{
 
 var contextSetCmd = &cobra.Command{
 	Use:               "set <name> <endpoint> <api-token>",
-	Short:             "create or overwrite a context",
+	Short:             "Creates or overwrite a context",
 	Args:              cobra.ExactArgs(3),
 	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE:              contextSetCmdFunc,
@@ -48,7 +48,7 @@ var contextSetCmd = &cobra.Command{
 
 var contextRemoveCmd = &cobra.Command{
 	Use:               "remove <system>",
-	Short:             "remove a context",
+	Short:             "Removes a context",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: ContextGet,
 	RunE:              contextRemoveCmdFunc,
@@ -56,7 +56,7 @@ var contextRemoveCmd = &cobra.Command{
 
 var contextUseCmd = &cobra.Command{
 	Use:               "use <system>",
-	Short:             "set a context as the current context",
+	Short:             "Sets a context as the current context",
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: ContextGet,
 	RunE:              contextUseCmdFunc,

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -31,33 +31,35 @@ var contextCmd = &cobra.Command{
 }
 
 var contextListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "list all contexts",
-	Args:  cobra.ExactArgs(0),
-	RunE:  contextListCmdFunc,
+	Use:               "list",
+	Short:             "list all contexts",
+	Args:              cobra.ExactArgs(0),
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE:              contextListCmdFunc,
 }
 
 var contextSetCmd = &cobra.Command{
-	Use:   "set <name> <endpoint> <api-token>",
-	Short: "create or overwrite a context",
-	Args:  cobra.ExactArgs(3),
-	RunE:  contextSetCmdFunc,
+	Use:               "set <name> <endpoint> <api-token>",
+	Short:             "create or overwrite a context",
+	Args:              cobra.ExactArgs(3),
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE:              contextSetCmdFunc,
 }
 
 var contextRemoveCmd = &cobra.Command{
 	Use:               "remove <system>",
 	Short:             "remove a context",
 	Args:              cobra.ExactArgs(1),
-	RunE:              contextRemoveCmdFunc,
 	ValidArgsFunction: ContextGet,
+	RunE:              contextRemoveCmdFunc,
 }
 
 var contextUseCmd = &cobra.Command{
 	Use:               "use <system>",
 	Short:             "set a context as the current context",
 	Args:              cobra.MaximumNArgs(1),
-	RunE:              contextUseCmdFunc,
 	ValidArgsFunction: ContextGet,
+	RunE:              contextUseCmdFunc,
 }
 
 func ContextGet(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -29,7 +29,7 @@ func registerImportCmd(rootCmd *cobra.Command) {
 
 var importCmd = &cobra.Command{
 	Use:   "import <url>",
-	Short: "import schema and relationships from a file or url",
+	Short: "Imports schema and relationships from a file or url",
 	Example: `
 	From a gist:
 		zed import https://gist.github.com/ecordell/8e3b613a677e3c844742cf24421c08b6

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -38,14 +38,14 @@ func registerAdditionalSchemaCmds(schemaCmd *cobra.Command) {
 var schemaWriteCmd = &cobra.Command{
 	Use:               "write <file?>",
 	Args:              cobra.MaximumNArgs(1),
-	Short:             "write a schema file (.zed or stdin) to the current permissions system",
+	Short:             "Write a schema file (.zed or stdin) to the current permissions system",
 	ValidArgsFunction: commands.FileExtensionCompletions("zed"),
 	RunE:              schemaWriteCmdFunc,
 }
 
 var schemaCopyCmd = &cobra.Command{
 	Use:               "copy <src context> <dest context>",
-	Short:             "copy a schema from one context into another",
+	Short:             "Copy a schema from one context into another",
 	Args:              cobra.ExactArgs(2),
 	ValidArgsFunction: ContextGet,
 	RunE:              schemaCopyCmdFunc,

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -36,17 +36,19 @@ func registerAdditionalSchemaCmds(schemaCmd *cobra.Command) {
 }
 
 var schemaWriteCmd = &cobra.Command{
-	Use:   "write <file?>",
-	Args:  cobra.MaximumNArgs(1),
-	Short: "write a Schema file (or stdin) to the current Permissions System",
-	RunE:  schemaWriteCmdFunc,
+	Use:               "write <file?>",
+	Args:              cobra.MaximumNArgs(1),
+	Short:             "write a schema file (.zed or stdin) to the current permissions system",
+	ValidArgsFunction: commands.FileExtensionCompletions("zed"),
+	RunE:              schemaWriteCmdFunc,
 }
 
 var schemaCopyCmd = &cobra.Command{
-	Use:   "copy <src context> <dest context>",
-	Args:  cobra.ExactArgs(2),
-	Short: "copy a Schema from one context into another",
-	RunE:  schemaCopyCmdFunc,
+	Use:               "copy <src context> <dest context>",
+	Short:             "copy a schema from one context into another",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: ContextGet,
+	RunE:              schemaCopyCmdFunc,
 }
 
 // TODO(jschorr): support this in the client package

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/authzed/spicedb/pkg/validationfile"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/authzed/zed/internal/commands"
 	"github.com/authzed/zed/internal/console"
 	"github.com/authzed/zed/internal/decode"
 	"github.com/authzed/zed/internal/printers"
@@ -41,7 +42,7 @@ func registerValidateCmd(rootCmd *cobra.Command) {
 
 var validateCmd = &cobra.Command{
 	Use:   "validate <validation_file_or_schema_file>",
-	Short: "validate the given validation or schema file",
+	Short: "Validates the given validation file (.yaml, .zaml) or schema file (.zed)",
 	Example: `
 	From a local file (with prefix):
 		zed validate file:///Users/zed/Downloads/authzed-x7izWU8_2Gw3.yaml
@@ -60,8 +61,9 @@ var validateCmd = &cobra.Command{
 
 	From a devtools instance:
 		zed validate https://localhost:8443/download`,
-	Args: cobra.ExactArgs(1),
-	RunE: validateCmdFunc,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: commands.FileExtensionCompletions("zed", "yaml", "zaml"),
+	RunE:              validateCmdFunc,
 }
 
 func validateCmdFunc(cmd *cobra.Command, args []string) error {

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -22,6 +22,12 @@ const (
 	SubjectTypeWithOptionalRelation
 )
 
+func FileExtensionCompletions(extension ...string) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return extension, cobra.ShellCompDirectiveFilterFileExt
+	}
+}
+
 func GetArgs(fields ...CompletionArgumentType) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		// Read the current schema, if any.

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -106,12 +106,12 @@ func RegisterPermissionCmd(rootCmd *cobra.Command) *cobra.Command {
 
 var permissionCmd = &cobra.Command{
 	Use:   "permission <subcommand>",
-	Short: "perform queries on the Permissions in a Permissions System",
+	Short: "Query the permissions in a permissions system",
 }
 
 var checkCmd = &cobra.Command{
 	Use:               "check <resource:id> <permission> <subject:id>",
-	Short:             "check that a Permission exists for a Subject",
+	Short:             "Check that a permission exists for a subject",
 	Args:              cobra.ExactArgs(3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectID),
 	RunE:              checkCmdFunc,
@@ -119,7 +119,7 @@ var checkCmd = &cobra.Command{
 
 var expandCmd = &cobra.Command{
 	Use:               "expand <permission> <resource:id>",
-	Short:             "expand the structure of a Permission",
+	Short:             "Expand the structure of a permission",
 	Args:              cobra.ExactArgs(2),
 	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE:              expandCmdFunc,
@@ -127,7 +127,7 @@ var expandCmd = &cobra.Command{
 
 var lookupResourcesCmd = &cobra.Command{
 	Use:               "lookup-resources <type> <permission> <subject:id>",
-	Short:             "looks up the Resources of a given type for which the Subject has Permission",
+	Short:             "Enumerates resources of a given type for which the subject has permission",
 	Args:              cobra.ExactArgs(3),
 	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
 	RunE:              lookupResourcesCmdFunc,
@@ -135,7 +135,7 @@ var lookupResourcesCmd = &cobra.Command{
 
 var lookupCmd = &cobra.Command{
 	Use:               "lookup <type> <permission> <subject:id>",
-	Short:             "lookup the Resources of a given type for which the Subject has Permission",
+	Short:             "Enumerates the resources of a given type for which the subject has permission",
 	Args:              cobra.ExactArgs(3),
 	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
 	RunE:              lookupResourcesCmdFunc,
@@ -144,7 +144,7 @@ var lookupCmd = &cobra.Command{
 
 var lookupSubjectsCmd = &cobra.Command{
 	Use:               "lookup-subjects <resource:id> <permission> <subject_type#optional_subject_relation>",
-	Short:             "lookup the Subjects of a given type for which the Subject has Permission on the Resource",
+	Short:             "Enumerates the subjects of a given type for which the subject has permission on the resource",
 	Args:              cobra.ExactArgs(3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              lookupSubjectsCmdFunc,

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -113,40 +113,41 @@ var checkCmd = &cobra.Command{
 	Use:               "check <resource:id> <permission> <subject:id>",
 	Short:             "check that a Permission exists for a Subject",
 	Args:              cobra.ExactArgs(3),
-	RunE:              checkCmdFunc,
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectID),
+	RunE:              checkCmdFunc,
 }
 
 var expandCmd = &cobra.Command{
-	Use:   "expand <permission> <resource:id>",
-	Short: "expand the structure of a Permission",
-	Args:  cobra.ExactArgs(2),
-	RunE:  expandCmdFunc,
+	Use:               "expand <permission> <resource:id>",
+	Short:             "expand the structure of a Permission",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: cobra.NoFileCompletions,
+	RunE:              expandCmdFunc,
 }
 
 var lookupResourcesCmd = &cobra.Command{
 	Use:               "lookup-resources <type> <permission> <subject:id>",
 	Short:             "looks up the Resources of a given type for which the Subject has Permission",
 	Args:              cobra.ExactArgs(3),
-	RunE:              lookupResourcesCmdFunc,
 	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
+	RunE:              lookupResourcesCmdFunc,
 }
 
 var lookupCmd = &cobra.Command{
 	Use:               "lookup <type> <permission> <subject:id>",
 	Short:             "lookup the Resources of a given type for which the Subject has Permission",
 	Args:              cobra.ExactArgs(3),
+	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
 	RunE:              lookupResourcesCmdFunc,
 	Hidden:            true,
-	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
 }
 
 var lookupSubjectsCmd = &cobra.Command{
 	Use:               "lookup-subjects <resource:id> <permission> <subject_type#optional_subject_relation>",
 	Short:             "lookup the Subjects of a given type for which the Subject has Permission on the Resource",
 	Args:              cobra.ExactArgs(3),
-	RunE:              lookupSubjectsCmdFunc,
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
+	RunE:              lookupSubjectsCmdFunc,
 }
 
 func checkCmdFunc(cmd *cobra.Command, args []string) error {

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -63,40 +63,40 @@ var createCmd = &cobra.Command{
 	Use:               "create <resource:id> <relation> <subject:id#optional_subject_relation>",
 	Short:             "create a Relationship for a Subject",
 	Args:              StdinOrExactArgs(3),
-	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_CREATE, os.Stdin),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
+	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_CREATE, os.Stdin),
 }
 
 var touchCmd = &cobra.Command{
 	Use:               "touch <resource:id> <relation> <subject:id#optional_subject_relation>",
 	Short:             "idempotently update a Relationship for a Subject",
 	Args:              StdinOrExactArgs(3),
-	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_TOUCH, os.Stdin),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
+	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_TOUCH, os.Stdin),
 }
 
 var deleteCmd = &cobra.Command{
 	Use:               "delete <resource:id> <relation> <subject:id#optional_subject_relation>",
 	Short:             "delete a Relationship",
 	Args:              StdinOrExactArgs(3),
-	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_DELETE, os.Stdin),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
+	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_DELETE, os.Stdin),
 }
 
 var readCmd = &cobra.Command{
 	Use:               "read <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation>",
 	Short:             "reads Relationships",
 	Args:              cobra.RangeArgs(1, 3),
-	RunE:              readRelationships,
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
+	RunE:              readRelationships,
 }
 
 var bulkDeleteCmd = &cobra.Command{
 	Use:               "bulk-delete <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation>",
 	Short:             "bulk delete Relationships",
 	Args:              cobra.RangeArgs(1, 3),
-	RunE:              bulkDeleteRelationships,
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
+	RunE:              bulkDeleteRelationships,
 }
 
 func StdinOrExactArgs(n int) cobra.PositionalArgs {

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -56,12 +56,12 @@ func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {
 
 var relationshipCmd = &cobra.Command{
 	Use:   "relationship <subcommand>",
-	Short: "perform CRUD operations on the Relationships in a Permissions System",
+	Short: "Query and mutate the relationships in a permissions system",
 }
 
 var createCmd = &cobra.Command{
 	Use:               "create <resource:id> <relation> <subject:id#optional_subject_relation>",
-	Short:             "create a Relationship for a Subject",
+	Short:             "Create a relationship for a subject",
 	Args:              StdinOrExactArgs(3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_CREATE, os.Stdin),
@@ -69,7 +69,7 @@ var createCmd = &cobra.Command{
 
 var touchCmd = &cobra.Command{
 	Use:               "touch <resource:id> <relation> <subject:id#optional_subject_relation>",
-	Short:             "idempotently update a Relationship for a Subject",
+	Short:             "Idempotently updates a relationship for a subject",
 	Args:              StdinOrExactArgs(3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_TOUCH, os.Stdin),
@@ -77,7 +77,7 @@ var touchCmd = &cobra.Command{
 
 var deleteCmd = &cobra.Command{
 	Use:               "delete <resource:id> <relation> <subject:id#optional_subject_relation>",
-	Short:             "delete a Relationship",
+	Short:             "Deletes a relationship",
 	Args:              StdinOrExactArgs(3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_DELETE, os.Stdin),
@@ -85,7 +85,7 @@ var deleteCmd = &cobra.Command{
 
 var readCmd = &cobra.Command{
 	Use:               "read <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation>",
-	Short:             "reads Relationships",
+	Short:             "Enumerates relationships matching the provided pattern",
 	Args:              cobra.RangeArgs(1, 3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              readRelationships,
@@ -93,7 +93,7 @@ var readCmd = &cobra.Command{
 
 var bulkDeleteCmd = &cobra.Command{
 	Use:               "bulk-delete <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation>",
-	Short:             "bulk delete Relationships",
+	Short:             "Deletes relationships matching the provided pattern en masse",
 	Args:              cobra.RangeArgs(1, 3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              bulkDeleteRelationships,

--- a/internal/commands/schema.go
+++ b/internal/commands/schema.go
@@ -31,10 +31,11 @@ var (
 	}
 
 	schemaReadCmd = &cobra.Command{
-		Use:   "read",
-		Args:  cobra.ExactArgs(0),
-		Short: "read the Schema of current Permissions System",
-		RunE:  schemaReadCmdFunc,
+		Use:               "read",
+		Short:             "read the Schema of current Permissions System",
+		Args:              cobra.ExactArgs(0),
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              schemaReadCmdFunc,
 	}
 )
 

--- a/internal/commands/schema.go
+++ b/internal/commands/schema.go
@@ -27,12 +27,12 @@ func RegisterSchemaCmd(rootCmd *cobra.Command) *cobra.Command {
 var (
 	schemaCmd = &cobra.Command{
 		Use:   "schema <subcommand>",
-		Short: "manages Schema for a Permissions System",
+		Short: "Manage schema for a permissions system",
 	}
 
 	schemaReadCmd = &cobra.Command{
 		Use:               "read",
-		Short:             "read the Schema of current Permissions System",
+		Short:             "Read the schema of a permissions system",
 		Args:              cobra.ExactArgs(0),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              schemaReadCmdFunc,

--- a/internal/commands/watch.go
+++ b/internal/commands/watch.go
@@ -31,7 +31,7 @@ func RegisterWatchCmd(rootCmd *cobra.Command) *cobra.Command {
 
 var watchCmd = &cobra.Command{
 	Use:   "watch [object_types, ...] [start_cursor]",
-	Short: "watches the stream of relationship updates from the server",
+	Short: "Watches the stream of relationship updates from the server",
 	Args:  cobra.RangeArgs(0, 2),
 	RunE:  watchCmdFunc,
 }


### PR DESCRIPTION
This PR does a few things
- consistently capitalizes usage text
- disables zsh's default file completion when not applicable
- uses file extensions for completion on schema/validation commands
- uses context completion for `zed schema copy`