### PR TITLE
Fix backup/restore per-second log output

### DIFF
--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -349,7 +349,7 @@ func backupCreateCmdFunc(cmd *cobra.Command, args []string) (err error) {
 	log.Info().
 		Uint("encoded", relsEncoded).
 		Uint("processed", relsProcessed).
-		Uint64("perSecond", perSec(uint64(relsProcessed), totalTime)).
+		Uint64("per_second", perSec(uint64(relsProcessed), totalTime)).
 		Stringer("duration", totalTime).
 		Msg("finished backup")
 

--- a/internal/cmd/restorer.go
+++ b/internal/cmd/restorer.go
@@ -200,7 +200,7 @@ func (r *restorer) restoreFromDecoder(ctx context.Context) error {
 		Int64("duplicate_relationships", r.duplicateRels).
 		Int64("relationships_filtered_out", r.filteredOutRels).
 		Int64("retried_errors", r.totalRetries).
-		Uint64("perSecond", perSec(uint64(r.writtenRels+r.skippedRels), totalTime)).
+		Uint64("per_second", perSec(uint64(r.writtenRels+r.skippedRels), totalTime)).
 		Stringer("duration", totalTime).
 		Msg("finished restore")
 	return nil


### PR DESCRIPTION
Use `per_second` instead of `perSecond` to align with underscore_case used for the other log values.