### PR TITLE
Respect resource ID filter when reading relationships

### DIFF
--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -181,16 +181,16 @@ func buildRelationshipsFilter(cmd *cobra.Command, args []string) (*v1.Relationsh
 	filter := &v1.RelationshipFilter{ResourceType: args[0]}
 
 	if strings.Contains(args[0], ":") {
-		resourceID := ""
+		var resourceID string
+		err := stringz.SplitExact(args[0], ":", &filter.ResourceType, &resourceID)
+		if err != nil {
+			return nil, err
+		}
+
 		if strings.HasSuffix(resourceID, "%") {
 			filter.OptionalResourceIdPrefix = strings.TrimSuffix(resourceID, "%")
 		} else {
 			filter.OptionalResourceId = resourceID
-		}
-
-		err := stringz.SplitExact(args[0], ":", &filter.ResourceType, &resourceID)
-		if err != nil {
-			return nil, err
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug in `zed relationship read` where the resource ID argument was not being applied, resulting in an incorrect filtering of relationships.

This regression was introduced by #341, which added filtering using prefixes.