### PR TITLE
Fix panic on permission check error

### DIFF
--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -206,7 +206,12 @@ func checkCmdFunc(cmd *cobra.Command, args []string) error {
 	var trailerMD metadata.MD
 	resp, err := client.CheckPermission(ctx, request, grpc.Trailer(&trailerMD))
 	if err != nil {
-		derr := displayDebugInformationIfRequested(cmd, resp.DebugTrace, trailerMD, true)
+		var debugInfo *v1.DebugInformation
+		if resp != nil {
+			debugInfo = resp.DebugTrace
+		}
+
+		derr := displayDebugInformationIfRequested(cmd, debugInfo, trailerMD, true)
 		if derr != nil {
 			return derr
 		}


### PR DESCRIPTION
Ensures that we nil check the response from a CheckPermission request before attempting to extract the debug info from it.

This regression was introduced in #354 where we added support for the new debug info in the response body rather than in HTTP trailers.