### PR TITLE
chore: fix the release error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           distribution: "goreleaser-pro"
           version: "latest"
-          args: "release --rm-dist"
+          args: "release --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           HOMEBREW_TAP_GITHUB_TOKEN: "${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}"
@@ -47,7 +47,7 @@ jobs:
         with:
           distribution: "goreleaser-pro"
           version: "latest"
-          args: "release --config=.goreleaser.docker.yml --rm-dist"
+          args: "release --config=.goreleaser.docker.yml --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"

--- a/.goreleaser.docker.yml
+++ b/.goreleaser.docker.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 builds:
   - id: "linux-amd64"
     goos: ["linux"]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 ---
+version: 2
 builds:
   - id: "linux-amd64-gnu"
     goos: ["linux"]


### PR DESCRIPTION
Close #398

https://github.com/authzed/zed/actions/runs/9942983136/job/27465721921

```
Run goreleaser/goreleaser-action@v6
Warning: You are using 'latest' as default version. Will lock to '~> v2'.
Downloading https://github.com/goreleaser/goreleaser-pro/releases/download/v2.1.0-pro/goreleaser-pro_Darwin_all.tar.gz
Extracting GoReleaser
/usr/bin/tar xz -C /Users/runner/work/_temp/a6eaee15-e2ed-4efa-8513-20ad884515ab -f /Users/runner/work/_temp/5997958d-49af-44fc-a94c-5beea7f0be38
GoReleaser latest installed successfully
/Users/runner/hostedtoolcache/goreleaser-action/2.1.0-pro/arm64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/Users/runner/hostedtoolcache/goreleaser-action/2.1.0-pro/arm64/goreleaser' failed with exit code 1
```

Updated GoReleaser config and command line options to support GoReleaser v2.

- https://goreleaser.com/deprecations/#-rm-dist
- https://goreleaser.com/blog/goreleaser-v2/?h=v2#upgrading
