### PR TITLE
Fix override CA certificate path

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -35,6 +35,7 @@ func newGRPCClient(cmd *cobra.Command) (Client, error) {
 	token, err := storage.DefaultToken(
 		cobrautil.MustGetString(cmd, "endpoint"),
 		cobrautil.MustGetString(cmd, "token"),
+		cobrautil.MustGetStringExpanded(cmd, "certificate-path"),
 		configStore,
 		secretStore,
 	)

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -31,6 +31,7 @@ func versionCmdFunc(cmd *cobra.Command, _ []string) error {
 		_, err := storage.DefaultToken(
 			cobrautil.MustGetString(cmd, "endpoint"),
 			cobrautil.MustGetString(cmd, "token"),
+			cobrautil.MustGetStringExpanded(cmd, "certificate-path"),
 			configStore,
 			secretStore,
 		)
@@ -48,6 +49,7 @@ func versionCmdFunc(cmd *cobra.Command, _ []string) error {
 		token, err := storage.DefaultToken(
 			cobrautil.MustGetString(cmd, "endpoint"),
 			cobrautil.MustGetString(cmd, "token"),
+			cobrautil.MustGetStringExpanded(cmd, "certificate-path"),
 			configStore,
 			secretStore,
 		)

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -37,18 +37,18 @@ func DefaultToken(
 	cs ConfigStore,
 	ss SecretStore,
 ) (Token, error) {
-	if overrideEndpoint != "" && overrideAPIToken != "" {
-		var overrideCACert []byte
-		if overrideCACertPath != "" {
-			caCert, err := os.ReadFile(overrideCACertPath)
-			if err != nil {
-				log.Error().
-					Str("certificate-path", overrideCACertPath).
-					Msg("failed to read CA certificate bundle")
-			}
-			overrideCACert = caCert
+	var overrideCACert []byte
+	if overrideCACertPath != "" {
+		caCert, err := os.ReadFile(overrideCACertPath)
+		if err != nil {
+			log.Error().
+				Str("certificate-path", overrideCACertPath).
+				Msg("failed to read CA certificate bundle")
 		}
+		overrideCACert = caCert
+	}
 
+	if overrideEndpoint != "" && overrideAPIToken != "" {
 		return Token{
 			Name:     "env",
 			Endpoint: overrideEndpoint,
@@ -73,7 +73,7 @@ func DefaultToken(
 		APIToken:   stringz.DefaultEmpty(overrideAPIToken, token.APIToken),
 		Insecure:   token.Insecure,
 		NoVerifyCA: token.NoVerifyCA,
-		CACert:     token.CACert,
+		CACert:     []byte(stringz.DefaultEmpty(string(overrideCACert), string(token.CACert))),
 	}, nil
 }
 

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -73,8 +73,15 @@ func DefaultToken(
 		APIToken:   stringz.DefaultEmpty(overrideAPIToken, token.APIToken),
 		Insecure:   token.Insecure,
 		NoVerifyCA: token.NoVerifyCA,
-		CACert:     []byte(stringz.DefaultEmpty(string(overrideCACert), string(token.CACert))),
+		CACert:     bytesDefaultEmpty(overrideCACert, token.CACert),
 	}, nil
+}
+
+func bytesDefaultEmpty(val, fallback []byte) []byte {
+	if len(val) == 0 {
+		return fallback
+	}
+	return val
 }
 
 // CurrentToken is convenient way to obtain the CurrentToken field from the


### PR DESCRIPTION
Closes https://github.com/authzed/zed/issues/244.

Hello,

Right now, it is impossible to override CA certificate bundle path in "headless mode". Users have to `context set` if they want to use a custom CA certificate bundle.

This PR fixes this issue by following the same pattern as `overrideEndpoint`.
