### PR TITLE
Add init that sets up logging for exceptional cases

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -3,10 +3,12 @@ package cmd
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/mattn/go-isatty"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
 	"github.com/rs/zerolog"
@@ -20,6 +22,25 @@ var (
 	SyncFlagsCmdFunc = cobrautil.SyncViperPreRunE("ZED")
 	errParsing       = errors.New("parsing error")
 )
+
+func init() {
+	// NOTE: this is mostly to set up logging in the case where
+	// the command doesn't exist or the construction of the command
+	// errors out before the PersistentPreRunE setup in the below function.
+	// It helps keep log output visually consistent for a user even in
+	// exceptional cases.
+	var output io.Writer
+
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		output = zerolog.ConsoleWriter{Out: os.Stderr}
+	} else {
+		output = os.Stderr
+	}
+
+	l := zerolog.New(output).With().Timestamp().Logger()
+
+	log.Logger = l
+}
 
 func Run() {
 	zl := cobrazerolog.New(cobrazerolog.WithPreRunLevel(zerolog.DebugLevel))

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -8,9 +8,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/mattn/go-isatty"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
+	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Fixes #368 

## Description
See #368. For error cases that were about missing commands or invalid argument sets, the logic that set up `zerolog` was never invoked, which meant that the output was a JSON blob instead of the prettily-formatted zerolog output. This makes the output more visually consistent.

## Changes
* Add `init` to command that sets up logging in the event that `zl.RunE` isn't actually called.
## Testing
Review. Checkout, `go build cmd/zed/..`, and run the resulting binary with some invalid args. `./main foo` and `./main validate` should do it.