### PR TITLE
Add non-empty passphrase constraint to context keyring

### DIFF
--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -129,7 +129,7 @@ const (
 	envRecommendation         = "Setting the environment variable `ZED_KEYRING_PASSWORD` to your password will skip prompts.\n"
 	keyringDoesNotExistPrompt = "Keyring file does not already exist.\nEnter a new non-empty passphrase for the new keyring file: "
 	keyringPrompt             = "Enter passphrase to unlock zed keyring: "
-	emptyKeyringPasswordError = "Your passphrase must not be empty."
+	emptyKeyringPasswordError = "your passphrase must not be empty"
 )
 
 func fileExists(path string) (bool, error) {


### PR DESCRIPTION
Fixes #192 

## Description
We've gotten reports of users unintentionally setting empty passphrases, either when setting contexts programmatically or unintentionally during setup on their local, and then not knowing what their password is. Forcing a user to set a non-empty passphrase should help with this.

## Changes
* Pull out a password prompt function
* Add assertion around empty passphrases on creation

## Testing
Add the following to the `keyring.Config` declaration in `internal/storage/secrets.go`:
```
AllowedBackends: []keyring.BackendType{"file"},
```
This will force it to use the file-based backend.

Build the binary and then run:

```
./zed context set foo foo:50051 sometoken --insecure
```

when it prompts you for a password, leave it empty and see that it errors.

Now repeat and set a non-empty password. Repeat and see that you can successfully decrypt the file.

Now repeat and attempt to use an empty password to decrypt. See that you receive a message about an incorrect password rather than "your password must be nonempty." This should cover the use case where a user currently intentionally has an empty passphrase set.