### PR TITLE
Add option for max message size

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -30,17 +30,6 @@ type Client interface {
 // NewClient defines an (overridable) means of creating a new client.
 var NewClient = newGRPCClient
 
-const oneGb = 1 * 1024 * 1024 * 1024
-
-var defaultCallOptions = grpc.WithDefaultCallOptions(
-	// The default max client message size is 4mb.
-	// It's conceivable that a sufficiently complex
-	// schema will easily surpass this, so we set the
-	// limit higher here.
-	grpc.MaxCallRecvMsgSize(oneGb),
-	grpc.MaxCallSendMsgSize(oneGb),
-)
-
 func newGRPCClient(cmd *cobra.Command) (Client, error) {
 	configStore, secretStore := DefaultStorage()
 	token, err := storage.DefaultToken(
@@ -54,14 +43,10 @@ func newGRPCClient(cmd *cobra.Command) (Client, error) {
 	}
 	log.Trace().Interface("token", token).Send()
 
-	flagDialOpts, err := DialOptsFromFlags(cmd, token)
+	dialOpts, err := DialOptsFromFlags(cmd, token)
 	if err != nil {
 		return nil, err
 	}
-
-	// NOTE: this works as long as we don't have CallOptions
-	// defined in flags. We'll have to modify this logic then.
-	dialOpts := append(flagDialOpts, defaultCallOptions)
 
 	client, err := authzed.NewClientWithExperimentalAPIs(token.Endpoint, dialOpts...)
 	if err != nil {
@@ -106,9 +91,19 @@ func DialOptsFromFlags(cmd *cobra.Command, token storage.Token) ([]grpc.DialOpti
 		interceptors = append(interceptors, zgrpcutil.CheckServerVersion)
 	}
 
+	maxMessageSize := cobrautil.MustGetInt(cmd, "max-message-size")
+
 	opts := []grpc.DialOption{
 		grpc.WithChainUnaryInterceptor(interceptors...),
 		grpc.WithChainStreamInterceptor(zgrpcutil.StreamLogDispatchTrailers),
+		grpc.WithDefaultCallOptions(
+			// The default max client message size is 4mb.
+			// It's conceivable that a sufficiently complex
+			// schema will easily surpass this, so we set the
+			// limit higher here.
+			grpc.MaxCallRecvMsgSize(maxMessageSize),
+			grpc.MaxCallSendMsgSize(maxMessageSize),
+		),
 	}
 
 	if cobrautil.MustGetBool(cmd, "insecure") || (token.IsInsecure()) {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -75,7 +75,7 @@ func Run() {
 	rootCmd.PersistentFlags().Bool("no-verify-ca", false, "do not attempt to verify the server's certificate chain and host name")
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().String("request-id", "", "optional id to send along with SpiceDB requests for tracing")
-	rootCmd.PersistentFlags().Int("max-message-size", 4*1024*1024, "maximum size (bytes) of a gRPC message sent or received by zed")
+	rootCmd.PersistentFlags().Int("max-message-size", 0, "maximum size (bytes) of a gRPC message that can be sent or received by zed")
 	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
 
 	versionCmd := &cobra.Command{

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -75,7 +75,7 @@ func Run() {
 	rootCmd.PersistentFlags().Bool("no-verify-ca", false, "do not attempt to verify the server's certificate chain and host name")
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().String("request-id", "", "optional id to send along with SpiceDB requests for tracing")
-	rootCmd.PersistentFlags().Int("max-message-size", 0, "maximum size (bytes) of a gRPC message that can be sent or received by zed")
+	rootCmd.PersistentFlags().Int("max-message-size", 0, "maximum size in bytes (defaults to 4mb) of a gRPC message that can be sent or received by zed")
 	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
 
 	versionCmd := &cobra.Command{

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -75,6 +75,7 @@ func Run() {
 	rootCmd.PersistentFlags().Bool("no-verify-ca", false, "do not attempt to verify the server's certificate chain and host name")
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().String("request-id", "", "optional id to send along with SpiceDB requests for tracing")
+	rootCmd.PersistentFlags().Int("max-message-size", 4*1024*1024, "maximum size (bytes) of a gRPC message sent or received by zed")
 	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
 
 	versionCmd := &cobra.Command{


### PR DESCRIPTION
## Description
We had a user run into an issue where `zed backup <filename>` failed with:
```
2:08PM ERR terminated with errors error="error receiving relationships: rpc error: code = ResourceExhausted desc = grpc: received message larger than max (6280392 vs. 4194304)"
```
This indicates that the client received a 6mb message with a max configured message size of 4mb, which is the default for a gRPC client.

This seems like something that could reasonably happen with a sufficiently large schema, especially if it has lots of comments.

My understanding is that this is a securityish feature meant to prevent a client from choking on an incoming message. It would also prevent a client from getting OOMkilled as a result of attempting to read a too-large message into memory. For the zed client, it seems like this isn't a concern, since it would typically be running on either a user's device or a CI server, neither of which are particularly memory-constrained.

## Changes
* Add a command line flag for dial opts that increase the max message size for both send and receive
## Testing
Review. See that tests still pass.