### PR TITLE
fixes context override

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,62 @@
+package client_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/authzed/zed/internal/client"
+	"github.com/authzed/zed/internal/storage"
+	zedtesting "github.com/authzed/zed/internal/testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTokenWithCLIOverride(t *testing.T) {
+	testCert, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	_, err = testCert.Write([]byte("hi"))
+	require.NoError(t, err)
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+		zedtesting.StringFlag{FlagName: "token", FlagValue: "t1", Changed: true},
+		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: testCert.Name(), Changed: true},
+		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: "e1", Changed: true},
+		zedtesting.BoolFlag{FlagName: "insecure", FlagValue: true, Changed: true},
+		zedtesting.BoolFlag{FlagName: "no-verify-ca", FlagValue: true, Changed: true},
+	)
+
+	bTrue := true
+	bFalse := false
+
+	// cli args take precedence when defined
+	to, err := client.GetTokenWithCLIOverride(cmd, storage.Token{})
+	require.NoError(t, err)
+	require.True(t, to.AnyValue())
+	require.Equal(t, "t1", to.APIToken)
+	require.Equal(t, "e1", to.Endpoint)
+	require.Equal(t, []byte("hi"), to.CACert)
+	require.Equal(t, &bTrue, to.Insecure)
+	require.Equal(t, &bTrue, to.NoVerifyCA)
+
+	// storage token takes precedence when defined
+	cmd = zedtesting.CreateTestCobraCommandWithFlagValue(t,
+		zedtesting.StringFlag{FlagName: "token", FlagValue: "", Changed: false},
+		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: "", Changed: false},
+		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: "", Changed: false},
+		zedtesting.BoolFlag{FlagName: "insecure", FlagValue: true, Changed: false},
+		zedtesting.BoolFlag{FlagName: "no-verify-ca", FlagValue: true, Changed: false},
+	)
+	to, err = client.GetTokenWithCLIOverride(cmd, storage.Token{
+		APIToken:   "t2",
+		Endpoint:   "e2",
+		CACert:     []byte("bye"),
+		Insecure:   &bFalse,
+		NoVerifyCA: &bFalse,
+	})
+	require.NoError(t, err)
+	require.True(t, to.AnyValue())
+	require.Equal(t, "t2", to.APIToken)
+	require.Equal(t, "e2", to.Endpoint)
+	require.Equal(t, []byte("bye"), to.CACert)
+	require.Equal(t, &bFalse, to.Insecure)
+	require.Equal(t, &bFalse, to.NoVerifyCA)
+}

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/authzed-go/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/generator"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
@@ -23,7 +22,6 @@ import (
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/commands"
 	"github.com/authzed/zed/internal/console"
-	"github.com/authzed/zed/internal/storage"
 )
 
 func registerAdditionalSchemaCmds(schemaCmd *cobra.Command) {
@@ -52,28 +50,14 @@ var schemaCopyCmd = &cobra.Command{
 	RunE:              schemaCopyCmdFunc,
 }
 
-// TODO(jschorr): support this in the client package
-func clientForContext(cmd *cobra.Command, contextName string, secretStore storage.SecretStore) (*authzed.Client, error) {
-	token, err := storage.GetToken(contextName, secretStore)
-	if err != nil {
-		return nil, err
-	}
-	log.Trace().Interface("token", token).Send()
-
-	dialOpts, err := client.DialOptsFromFlags(cmd, token)
-	if err != nil {
-		return nil, err
-	}
-	return authzed.NewClient(token.Endpoint, dialOpts...)
-}
-
 func schemaCopyCmdFunc(cmd *cobra.Command, args []string) error {
 	_, secretStore := client.DefaultStorage()
-	srcClient, err := clientForContext(cmd, args[0], secretStore)
+	srcClient, err := client.NewClientForContext(cmd, args[0], secretStore)
 	if err != nil {
 		return err
 	}
-	destClient, err := clientForContext(cmd, args[1], secretStore)
+
+	destClient, err := client.NewClientForContext(cmd, args[1], secretStore)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/config_test.go
+++ b/internal/storage/config_test.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenWithOverride(t *testing.T) {
+	bTrue := true
+	referenceToken := Token{
+		Name:       "n1",
+		Endpoint:   "e1",
+		APIToken:   "a1",
+		Insecure:   &bTrue,
+		NoVerifyCA: &bTrue,
+		CACert:     []byte("c1"),
+	}
+
+	bFalse := false
+	override := Token{
+		Name:       "n2",
+		Endpoint:   "e2",
+		APIToken:   "a2",
+		Insecure:   &bFalse,
+		NoVerifyCA: &bFalse,
+		CACert:     []byte("c2"),
+	}
+
+	result, err := TokenWithOverride(override, referenceToken)
+	require.NoError(t, err)
+	require.Equal(t, "n1", result.Name)
+	require.Equal(t, "e2", result.Endpoint)
+	require.Equal(t, "a2", result.APIToken)
+	require.Equal(t, false, *result.Insecure)
+	require.Equal(t, false, *result.NoVerifyCA)
+	require.Equal(t, 0, bytes.Compare([]byte("c2"), result.CACert))
+
+	result, err = TokenWithOverride(Token{}, referenceToken)
+	require.NoError(t, err)
+	require.Equal(t, "n1", result.Name)
+	require.Equal(t, "e1", result.Endpoint)
+	require.Equal(t, "a1", result.APIToken)
+	require.Equal(t, true, *result.Insecure)
+	require.Equal(t, true, *result.NoVerifyCA)
+	require.Equal(t, 0, bytes.Compare([]byte("c1"), result.CACert))
+}

--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -26,6 +26,14 @@ type Token struct {
 	CACert     []byte
 }
 
+func (t Token) AnyValue() bool {
+	if t.Endpoint != "" || t.APIToken != "" || t.Insecure != nil || t.NoVerifyCA != nil || len(t.CACert) > 0 {
+		return true
+	}
+
+	return false
+}
+
 func (t Token) Certificate() (cert []byte, ok bool) {
 	if len(t.CACert) > 0 {
 		return t.CACert, true

--- a/internal/storage/secrets_test.go
+++ b/internal/storage/secrets_test.go
@@ -1,0 +1,19 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenAnyValue(t *testing.T) {
+	b := false
+
+	require.False(t, Token{}.AnyValue())
+	require.False(t, Token{}.AnyValue())
+	require.True(t, Token{Endpoint: "foo"}.AnyValue())
+	require.True(t, Token{APIToken: "foo"}.AnyValue())
+	require.True(t, Token{Insecure: &b}.AnyValue())
+	require.True(t, Token{NoVerifyCA: &b}.AnyValue())
+	require.True(t, Token{CACert: []byte("a")}.AnyValue())
+}

--- a/internal/testing/test_helpers.go
+++ b/internal/testing/test_helpers.go
@@ -64,31 +64,37 @@ func NewTestServer(ctx context.Context, t *testing.T) server.RunnableServer {
 type StringFlag struct {
 	FlagName  string
 	FlagValue string
+	Changed   bool
 }
 
 type BoolFlag struct {
 	FlagName  string
 	FlagValue bool
+	Changed   bool
 }
 
 type IntFlag struct {
 	FlagName  string
 	FlagValue int
+	Changed   bool
 }
 
 type UintFlag struct {
 	FlagName  string
 	FlagValue uint
+	Changed   bool
 }
 
 type UintFlag32 struct {
 	FlagName  string
 	FlagValue uint32
+	Changed   bool
 }
 
 type DurationFlag struct {
 	FlagName  string
 	FlagValue time.Duration
+	Changed   bool
 }
 
 func CreateTestCobraCommandWithFlagValue(t *testing.T, flagAndValues ...any) *cobra.Command {
@@ -99,16 +105,22 @@ func CreateTestCobraCommandWithFlagValue(t *testing.T, flagAndValues ...any) *co
 		switch f := flagAndValue.(type) {
 		case StringFlag:
 			c.Flags().String(f.FlagName, f.FlagValue, "")
+			c.Flag(f.FlagName).Changed = f.Changed
 		case BoolFlag:
 			c.Flags().Bool(f.FlagName, f.FlagValue, "")
+			c.Flag(f.FlagName).Changed = f.Changed
 		case IntFlag:
 			c.Flags().Int(f.FlagName, f.FlagValue, "")
+			c.Flag(f.FlagName).Changed = f.Changed
 		case UintFlag:
 			c.Flags().Uint(f.FlagName, f.FlagValue, "")
+			c.Flag(f.FlagName).Changed = f.Changed
 		case UintFlag32:
 			c.Flags().Uint32(f.FlagName, f.FlagValue, "")
+			c.Flag(f.FlagName).Changed = f.Changed
 		case DurationFlag:
 			c.Flags().Duration(f.FlagName, f.FlagValue, "")
+			c.Flag(f.FlagName).Changed = f.Changed
 		default:
 			t.Fatalf("unknown flag type: %T", f)
 		}


### PR DESCRIPTION
A customer reported flags being ignored even when
they were being provided via CLI arguments.

The behavior of overriding current context via
CLI arguments was inconsistent across the codebase. This centralizes the logic so all the various commands use the same logic.