### PR TITLE
Get rid of anchor syntax in release yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,9 @@ jobs:
       - uses: "goreleaser/goreleaser-action@v6"
         with:
           distribution: "goreleaser-pro"
-          version: &goreleaser_version "2.3.2"
+          # NOTE: keep in sync with goreleaser version in other job.
+          # github actions don't allow yaml anchors.
+          version: "2.3.2"
           args: "release --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -46,7 +48,9 @@ jobs:
       - uses: "goreleaser/goreleaser-action@v6"
         with:
           distribution: "goreleaser-pro"
-          version: *goreleaser_version
+          # NOTE: keep in sync with goreleaser version in other job.
+          # github actions don't allow yaml anchors.
+          version: "2.3.2"
           args: "release --config=.goreleaser.docker.yml --clean"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fixes #418 

## Description
Turns out github actions don't support yaml anchors: actions/runner#1182

This caused the bug reported in the issue.

## Changes
* Get rid of yaml anchor syntax
## Testing
Review. Cut a release and see that it succeeds.