### PR TITLE
Fix CLI usage with no pre-set context/config

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -74,6 +74,14 @@ func newClientForContext(cmd *cobra.Command, contextName string, secretStore sto
 
 // GetCurrentTokenWithCLIOverride returns the current token, but overridden by any parameter specified via CLI args
 func GetCurrentTokenWithCLIOverride(cmd *cobra.Command, configStore storage.ConfigStore, secretStore storage.SecretStore) (storage.Token, error) {
+	// Handle the no-config case separately
+	configExists, err := configStore.Exists()
+	if err != nil {
+		return storage.Token{}, err
+	}
+	if !configExists {
+		return GetTokenWithCLIOverride(cmd, storage.Token{})
+	}
 	token, err := storage.CurrentToken(
 		configStore,
 		secretStore,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -54,7 +54,7 @@ func newClientForCurrentContext(cmd *cobra.Command) (Client, error) {
 }
 
 func newClientForContext(cmd *cobra.Command, contextName string, secretStore storage.SecretStore) (*authzed.Client, error) {
-	currentToken, err := storage.GetToken(contextName, secretStore)
+	currentToken, err := storage.GetTokenIfExists(contextName, secretStore)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -104,7 +104,7 @@ func TestGetCurrentTokenWithCLIOverrideWithoutSecretFile(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "")
 	require.NoError(err)
 	configPath := path.Join(tmpDir, "config.json")
-	err = os.WriteFile(configPath, []byte("{}"), 0600)
+	err = os.WriteFile(configPath, []byte("{}"), 0o600)
 	require.NoError(err)
 
 	configStore := &storage.JSONConfigStore{ConfigPath: tmpDir}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -65,7 +65,7 @@ func TestGetTokenWithCLIOverride(t *testing.T) {
 
 func TestGetCurrentTokenWithCLIOverrideWithoutConfigFile(t *testing.T) {
 	// When we refactored the token setting logic, we broke the workflow where zed is used without a saved
-	// context. This asserts that that workflow works.
+	// configuration. This asserts that that workflow works.
 	require := require.New(t)
 	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
 		zedtesting.StringFlag{FlagName: "token", FlagValue: "t1", Changed: true},

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -118,19 +118,3 @@ func TestGetCurrentTokenWithCLIOverrideWithoutSecretFile(t *testing.T) {
 	require.Equal("e1", token.Endpoint)
 	require.Equal(&bTrue, token.Insecure)
 }
-
-func TestGetCurrentTokenWithCLIOverrideWithInsufficientArgs (t *testing.T) {
-	// This is to ensure that insufficient args don't unintentionally validate.
-	require := require.New(t)
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
-		zedtesting.StringFlag{FlagName: "token", FlagValue: "", Changed: false},
-		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: "e1", Changed: true},
-		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: "", Changed: false},
-	)
-
-	configStore, secretStore := client.DefaultStorage()
-	_, err := client.GetCurrentTokenWithCLIOverride(cmd, configStore, secretStore)
-
-	// cli args take precedence when defined
-	require.NoError(err)
-}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -85,7 +85,8 @@ func TestGetCurrentTokenWithCLIOverrideWithoutConfigFile(t *testing.T) {
 	require.True(token.AnyValue())
 	require.Equal("t1", token.APIToken)
 	require.Equal("e1", token.Endpoint)
-	require.Equal(&bTrue, token.Insecure)
+	require.NotNil(token.Insecure)
+	require.True(*token.Insecure)
 }
 
 func TestGetCurrentTokenWithCLIOverrideWithoutSecretFile(t *testing.T) {

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -74,8 +74,6 @@ func TestGetCurrentTokenWithCLIOverrideWithoutConfigFile(t *testing.T) {
 		zedtesting.BoolFlag{FlagName: "insecure", FlagValue: true, Changed: true},
 	)
 
-	bTrue := true
-
 	configStore := &storage.JSONConfigStore{ConfigPath: "/not/a/valid/path"}
 	secretStore := &storage.KeychainSecretStore{ConfigPath: "/not/a/valid/path"}
 	token, err := client.GetCurrentTokenWithCLIOverride(cmd, configStore, secretStore)

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -28,6 +28,7 @@ type Config struct {
 type ConfigStore interface {
 	Get() (Config, error)
 	Put(Config) error
+	Exists() (bool, error)
 }
 
 // TokenWithOverride returns a Token that retrieves its values from the reference Token, and has its values overridden
@@ -145,6 +146,17 @@ func (s JSONConfigStore) Put(cfg Config) error {
 	}
 
 	return atomicWriteFile(filepath.Join(s.ConfigPath, configFileName), cfgBytes, 0o774)
+}
+
+func (s JSONConfigStore) Exists() (bool, error) {
+	_, err := os.Stat(filepath.Join(s.ConfigPath, configFileName))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // atomicWriteFile writes data to filename+some suffix, then renames it into

--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -14,9 +14,6 @@ import (
 	"github.com/authzed/zed/internal/console"
 )
 
-// ErrTokenNotFound is returned if there is no Token in a ConfigStore.
-var ErrTokenNotFound = errors.New("token does not exist")
-
 type Token struct {
 	Name       string
 	Endpoint   string
@@ -72,7 +69,8 @@ type SecretStore interface {
 	Put(s Secrets) error
 }
 
-func GetToken(name string, ss SecretStore) (Token, error) {
+// Returns an empty token if no token exists.
+func GetTokenIfExists(name string, ss SecretStore) (Token, error) {
 	secrets, err := ss.Get()
 	if err != nil {
 		return Token{}, err
@@ -84,7 +82,22 @@ func GetToken(name string, ss SecretStore) (Token, error) {
 		}
 	}
 
-	return Token{}, ErrTokenNotFound
+	return Token{}, nil
+}
+
+func TokenExists(name string, ss SecretStore) (bool, error) {
+	secrets, err := ss.Get()
+	if err != nil {
+		return false, err
+	}
+
+	for _, token := range secrets.Tokens {
+		if name == token.Name {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func PutToken(t Token, ss SecretStore) error {


### PR DESCRIPTION
## Description
In #417 we introduced a bug where `zed` became unusable if there wasn't previously a context set by the user. This wasn't intentional; it should be valid to invoke zed entirely from the command line in isolation. This PR captures that behavior in a unit test and fixes the behavior.

## Changes
* Separate existence and fetching concerns for tokens
* Handle cases where config file or token don't exist
## Testing
See that tests go green. See that you can clear out your local context (or run from within a container): `/zed schema write ./blah.zed --endpoint 127.0.0.1:50051 --token supersecretdevkey --insecure` and not receive an error.