### PR TITLE
Document resource ID prefix filtering

### DIFF
--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -86,9 +86,17 @@ var deleteCmd = &cobra.Command{
 	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_DELETE, os.Stdin),
 }
 
+const readCmdHelpLong = `Enumerates relationships matching the provided pattern.
+
+To filter returned relationships using a resource ID prefix, append a '%' to the resource ID:
+
+zed relationship read some-type:some-prefix-%
+`
+
 var readCmd = &cobra.Command{
 	Use:               "read <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation>",
 	Short:             "Enumerates relationships matching the provided pattern",
+	Long:              readCmdHelpLong,
 	Args:              cobra.RangeArgs(1, 3),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              readRelationships,


### PR DESCRIPTION
Adds an example to the help output for `zed relationship read` with an example of how to filter the results using a resource ID prefix.

**New output:**
```
$ zed relationship read --help
Enumerates relationships matching the provided pattern.

To filter returned relationships using a resource ID prefix, append a '%' to the resource ID:

zed relationship read some-type:some-prefix-%

Usage:
  zed relationship read <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation> [flags]
```