### PR TITLE
Added multiple validation files parsing support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
 	github.com/authzed/authzed-go v1.2.2-0.20250107172318-7fd4159ab2b7
 	github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b
-	github.com/authzed/spicedb v1.39.1-0.20250108165209-c18b1656bdd0
+	github.com/authzed/spicedb v1.39.1-0.20250114225336-a80f596434e3
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/ccoveille/go-safecast v1.5.0
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -261,5 +261,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/authzed/spicedb => github.com/kartikaysaxena/spicedb v0.0.0-20250113154244-813e62735279

--- a/go.mod
+++ b/go.mod
@@ -261,3 +261,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/authzed/spicedb => github.com/kartikaysaxena/spicedb v0.0.0-20250113154244-813e62735279

--- a/go.sum
+++ b/go.sum
@@ -678,8 +678,6 @@ github.com/authzed/consistent v0.1.0 h1:tlh1wvKoRbjRhMm2P+X5WQQyR54SRoS4MyjLOg17
 github.com/authzed/consistent v0.1.0/go.mod h1:plwHlrN/EJUCwQ+Bca0MhM1KnisPs7HEkZI5giCXrcc=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b h1:wbh8IK+aMLTCey9sZasO7b6BWLAJnHHvb79fvWCXwxw=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b/go.mod h1:s3qC7V7XIbiNWERv7Lfljy/Lx25/V1Qlexb0WJuA8uQ=
-github.com/authzed/spicedb v1.39.1-0.20250108165209-c18b1656bdd0 h1:ewOiKCJmuLU7/+HyUrJD/oIMgd7NG0NrpHfl4nzeW/s=
-github.com/authzed/spicedb v1.39.1-0.20250108165209-c18b1656bdd0/go.mod h1:/UVC4ZJkMUZFN4MVjjOLAU7m/fqitkBP57ZPffyicOs=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=
 github.com/aws/aws-sdk-go-v2 v1.32.7/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/config v1.28.7 h1:GduUnoTXlhkgnxTD93g1nv4tVPILbdNQOzav+Wpg7AE=
@@ -1119,6 +1117,8 @@ github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f h1:+WgAZQQ
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f/go.mod h1:jsl6cEF6BT3UeQoSLreA7G0sZXemoI5XNqyxzWCohbE=
 github.com/jzelinskie/stringz v0.0.3 h1:0GhG3lVMYrYtIvRbxvQI6zqRTT1P1xyQlpa0FhfUXas=
 github.com/jzelinskie/stringz v0.0.3/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
+github.com/kartikaysaxena/spicedb v0.0.0-20250113154244-813e62735279 h1:rX8BE4sozX/QQ+ViPUohSf8kPGn61zEsgT7bS8OKV1Q=
+github.com/kartikaysaxena/spicedb v0.0.0-20250113154244-813e62735279/go.mod h1:/UVC4ZJkMUZFN4MVjjOLAU7m/fqitkBP57ZPffyicOs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -678,6 +678,8 @@ github.com/authzed/consistent v0.1.0 h1:tlh1wvKoRbjRhMm2P+X5WQQyR54SRoS4MyjLOg17
 github.com/authzed/consistent v0.1.0/go.mod h1:plwHlrN/EJUCwQ+Bca0MhM1KnisPs7HEkZI5giCXrcc=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b h1:wbh8IK+aMLTCey9sZasO7b6BWLAJnHHvb79fvWCXwxw=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b/go.mod h1:s3qC7V7XIbiNWERv7Lfljy/Lx25/V1Qlexb0WJuA8uQ=
+github.com/authzed/spicedb v1.39.1-0.20250114225336-a80f596434e3 h1:2bnplEAOp5f8Z4OuH+fm09TbZU2GxxSZnEhPpAzkwW0=
+github.com/authzed/spicedb v1.39.1-0.20250114225336-a80f596434e3/go.mod h1:/UVC4ZJkMUZFN4MVjjOLAU7m/fqitkBP57ZPffyicOs=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=
 github.com/aws/aws-sdk-go-v2 v1.32.7/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
 github.com/aws/aws-sdk-go-v2/config v1.28.7 h1:GduUnoTXlhkgnxTD93g1nv4tVPILbdNQOzav+Wpg7AE=
@@ -1117,8 +1119,6 @@ github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f h1:+WgAZQQ
 github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f/go.mod h1:jsl6cEF6BT3UeQoSLreA7G0sZXemoI5XNqyxzWCohbE=
 github.com/jzelinskie/stringz v0.0.3 h1:0GhG3lVMYrYtIvRbxvQI6zqRTT1P1xyQlpa0FhfUXas=
 github.com/jzelinskie/stringz v0.0.3/go.mod h1:hHYbgxJuNLRw91CmpuFsYEOyQqpDVFg8pvEh23vy4P0=
-github.com/kartikaysaxena/spicedb v0.0.0-20250113154244-813e62735279 h1:rX8BE4sozX/QQ+ViPUohSf8kPGn61zEsgT7bS8OKV1Q=
-github.com/kartikaysaxena/spicedb v0.0.0-20250113154244-813e62735279/go.mod h1:/UVC4ZJkMUZFN4MVjjOLAU7m/fqitkBP57ZPffyicOs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -72,7 +72,7 @@ func importCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	decoder, err := decode.DecoderForURL(u)
+	decoder, err := decode.DecoderForURL(u, args)
 	if err != nil {
 		return err
 	}

--- a/internal/decode/decoder.go
+++ b/internal/decode/decoder.go
@@ -107,13 +107,14 @@ func directHTTPDecoder(u *url.URL) Func {
 
 // Uses the files passed in the args and looks for the specified schemaFile to parse the YAML.
 func unmarshalAsYAMLOrSchemaWithFile(data []byte, out interface{}, args []string) (bool, error) {
-	if strings.Contains(string(data), "schemaFile:") {
+	if (strings.Contains(string(data), "schemaFile:") && !strings.Contains(string(data), "schema:")) {
 		if err := yaml.Unmarshal(data, out); err != nil {
 			return false, err
 		}
 		schema := out.(*validationfile.ValidationFile)
 
 		for _, arg := range args {
+			// Check if the file specified in schemaFile is passed as an arguement.
 			if strings.Contains(arg, schema.SchemaFile) {
 				file, err := os.Open(arg)
 				if err != nil {
@@ -131,7 +132,7 @@ func unmarshalAsYAMLOrSchemaWithFile(data []byte, out interface{}, args []string
 
 func unmarshalAsYAMLOrSchema(data []byte, out interface{}) (bool, error) {
 	// Check for indications of a schema-only file.
-	if !strings.Contains(string(data), "schema:") {
+	if (!strings.Contains(string(data), "schema:") && !strings.Contains(string(data), "relationships:")) {
 		compiled, serr := compiler.Compile(compiler.InputSchema{
 			Source:       input.Source("schema"),
 			SchemaString: string(data),

--- a/internal/decode/decoder.go
+++ b/internal/decode/decoder.go
@@ -107,7 +107,7 @@ func directHTTPDecoder(u *url.URL) Func {
 
 // Uses the files passed in the args and looks for the specified schemaFile to parse the YAML.
 func unmarshalAsYAMLOrSchemaWithFile(data []byte, out interface{}, args []string) (bool, error) {
-	if (strings.Contains(string(data), "schemaFile:") && !strings.Contains(string(data), "schema:")) {
+	if strings.Contains(string(data), "schemaFile:") && !strings.Contains(string(data), "schema:") {
 		if err := yaml.Unmarshal(data, out); err != nil {
 			return false, err
 		}
@@ -132,7 +132,7 @@ func unmarshalAsYAMLOrSchemaWithFile(data []byte, out interface{}, args []string
 
 func unmarshalAsYAMLOrSchema(data []byte, out interface{}) (bool, error) {
 	// Check for indications of a schema-only file.
-	if (!strings.Contains(string(data), "schema:") && !strings.Contains(string(data), "relationships:")) {
+	if !strings.Contains(string(data), "schema:") && !strings.Contains(string(data), "relationships:") {
 		compiled, serr := compiler.Compile(compiler.InputSchema{
 			Source:       input.Source("schema"),
 			SchemaString: string(data),


### PR DESCRIPTION
Related #453 #454

`zed validate` now takes in multiple args to validate, also looks for `schemaFile` in given .yaml validation files to parse the schema. Example usage:-

```
(base) Kartikay2@Kartikays-MacBook-Pro-2 zed % ./zed validate validations/*
warning: Arrow `parent->reader` under permission "view" references relation "reader" on definition "folder"; it is recommended to point to a permission (arrow-references-relation)
 25 |       relation auditor: user with day_of_a_week
 26 | 
 27 | 
 28 >       // can user:kartikay view document:quartely_planning
 29 |       permission view = reader + owner + parent->reader + auditor
 30 |       permission edit = owner + parent->owner
 25 |     - "[user:owner_1] is <document:quaterly_planning#owner>"
 26 |     - "[user:owner_2] is <document:quaterly_planning#owner>"
 27 |   document:quaterly_planning#parent:
 28 >     - "[folder:planning] is <document:quaterly_planning#parent>"
 29 |   document:quaterly_planning#view:
 30 |     - "[user:auditorhere[...]] is <document:quaterly_planning#auditor>"
 25 | 
 26 | 
 27 |     // can user:kartikay view document:quartely_planning
 28 >     permission view = reader + owner + parent->reader + auditor
    >                                        ^~~~~~~~~~~~~~
 29 |     permission edit = owner + parent->owner
 30 |     permission delete = owner + parent->owner

warning: Arrow `parent->owner` under permission "edit" references relation "owner" on definition "folder"; it is recommended to point to a permission (arrow-references-relation)
 26 | 
 27 | 
 28 |       // can user:kartikay view document:quartely_planning
 29 >       permission view = reader + owner + parent->reader + auditor
 30 |       permission edit = owner + parent->owner
 31 |       permission delete = owner + parent->owner
 26 |     - "[user:owner_2] is <document:quaterly_planning#owner>"
 27 |   document:quaterly_planning#parent:
 28 |     - "[folder:planning] is <document:quaterly_planning#parent>"
 29 >   document:quaterly_planning#view:
 30 |     - "[user:auditorhere[...]] is <document:quaterly_planning#auditor>"
 31 |     - "[user:folder_reader_1] is <folder:planning#reader>"
 26 | 
 27 |     // can user:kartikay view document:quartely_planning
 28 |     permission view = reader + owner + parent->reader + auditor
 29 >     permission edit = owner + parent->owner
    >                               ^~~~~~~~~~~~~
 30 |     permission delete = owner + parent->owner
 31 | }

warning: Arrow `parent->owner` under permission "delete" references relation "owner" on definition "folder"; it is recommended to point to a permission (arrow-references-relation)
 27 | 
 28 |       // can user:kartikay view document:quartely_planning
 29 |       permission view = reader + owner + parent->reader + auditor
 30 >       permission edit = owner + parent->owner
    >                                 ^~~~~~~~~~~~~
 31 |       permission delete = owner + parent->owner
 32 |   }
 27 |   document:quaterly_planning#parent:
 28 |     - "[folder:planning] is <document:quaterly_planning#parent>"
 29 |   document:quaterly_planning#view:
 30 >     - "[user:auditorhere[...]] is <document:quaterly_planning#auditor>"
 31 |     - "[user:folder_reader_1] is <folder:planning#reader>"
 32 |     - "[user:owner_1] is <document:quaterly_planning#owner>"
 27 |     // can user:kartikay view document:quartely_planning
 28 |     permission view = reader + owner + parent->reader + auditor
 29 |     permission edit = owner + parent->owner
 30 >     permission delete = owner + parent->owner
    >                                 ^~~~~~~~~~~~~
 31 | }

complete - 26 relationships loaded, 2 assertions run, 8 expected relations validated
total files: 3, successfully validated files: 3
```
Edit: Raised authzed/spicedb#2206 to introduce schemaFile which would fix the tests here too