### PR TITLE
Fixes for zed validate on multiple files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 dist/
+
+# Local-only files
+go.work
+go.work.sum

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -72,7 +72,7 @@ func importCmdFunc(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	decoder, err := decode.DecoderForURL(u, args)
+	decoder, err := decode.DecoderForURL(u)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
I noticed that if I validate multiple files, the output looks like `Success!Success!Success!` which isn't ideal. This fixes that and prettifies the output some.

The current approach also reuses the context for relationships, which means that individual validation files share relationships and will step on each others' toes.

## Changes
* Add go.work files to gitignore
* Reorganize multiple-file loop
* Relax requirement to pass schema as argument

## Testing
Review. Disable whitespace for a nicer experience. Set up a folder with a few schema files in it and run `go run ./cmd/zed/... validate folder/*` and see that the output looks nice.