### PR TITLE
Fix import behavior

### DIFF
--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -9,6 +9,7 @@ import (
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/validationfile"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -76,7 +77,7 @@ func importCmdFunc(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	var p decode.SchemaRelationships
+	var p validationfile.ValidationFile
 	if _, _, err := decoder(&p); err != nil {
 		return err
 	}
@@ -87,7 +88,7 @@ func importCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	if cobrautil.MustGetBool(cmd, "schema") {
-		if err := importSchema(cmd.Context(), client, p.Schema, prefix); err != nil {
+		if err := importSchema(cmd.Context(), client, p.Schema.Schema, prefix); err != nil {
 			return err
 		}
 	}
@@ -95,7 +96,7 @@ func importCmdFunc(cmd *cobra.Command, args []string) error {
 	if cobrautil.MustGetBool(cmd, "relationships") {
 		batchSize := cobrautil.MustGetInt(cmd, "batch-size")
 		workers := cobrautil.MustGetInt(cmd, "workers")
-		if err := importRelationships(cmd.Context(), client, p.Relationships, prefix, batchSize, workers); err != nil {
+		if err := importRelationships(cmd.Context(), client, p.Relationships.RelationshipsString, prefix, batchSize, workers); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/import_test.go
+++ b/internal/cmd/import_test.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/zed/internal/client"
+	zedtesting "github.com/authzed/zed/internal/testing"
+)
+
+var fullyConsistent = &v1.Consistency{Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true}}
+
+func TestImportCmdHappyPath(t *testing.T) {
+	require := require.New(t)
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+		zedtesting.StringFlag{FlagName: "schema-definition-prefix"},
+		zedtesting.BoolFlag{FlagName: "schema", FlagValue: true},
+		zedtesting.BoolFlag{FlagName: "relationships", FlagValue: true},
+		zedtesting.IntFlag{FlagName: "batch-size", FlagValue: 100},
+		zedtesting.IntFlag{FlagName: "workers", FlagValue: 1},
+	)
+	f := filepath.Join("test", "happy-path-validation-file.yaml")
+
+	// Set up client
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := zedtesting.NewTestServer(ctx, t)
+	go func() {
+		require.NoError(srv.Run(ctx))
+	}()
+	conn, err := srv.GRPCDialContext(ctx)
+	require.NoError(err)
+
+	originalClient := client.NewClient
+	defer func() {
+		client.NewClient = originalClient
+	}()
+
+	client.NewClient = zedtesting.ClientFromConn(conn)
+
+	c, err := zedtesting.ClientFromConn(conn)(cmd)
+	require.NoError(err)
+
+	// Run the import and assert we don't have errors
+	err = importCmdFunc(cmd, []string{f})
+	require.NoError(err)
+
+	// Run a check with full consistency to see whether the relationships
+	// and schema are written
+	resp, err := c.CheckPermission(ctx, &v1.CheckPermissionRequest{
+		Consistency: fullyConsistent,
+		Subject:     &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "1"}},
+		Permission:  "view",
+		Resource:    &v1.ObjectReference{ObjectType: "resource", ObjectId: "1"},
+	})
+	require.NoError(err)
+	require.Equal(resp.Permissionship, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION)
+}

--- a/internal/cmd/test/happy-path-validation-file.yaml
+++ b/internal/cmd/test/happy-path-validation-file.yaml
@@ -1,0 +1,9 @@
+---
+schemaFile: "./happy-path-validation-schema.zed"
+relationships: >-
+  resource:1#user@user:1
+assertions:
+  assertTrue:
+    - "resource:1#user@user:1"
+  assertFalse:
+    - "resource:1#user@user:2"

--- a/internal/cmd/test/happy-path-validation-schema.zed
+++ b/internal/cmd/test/happy-path-validation-schema.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+  relation user: user
+  permission view = user
+}

--- a/internal/decode/decoder.go
+++ b/internal/decode/decoder.go
@@ -113,7 +113,10 @@ func unmarshalAsYAMLOrSchemaWithFile(data []byte, out interface{}, filename stri
 		if err := yaml.Unmarshal(data, out); err != nil {
 			return false, err
 		}
-		validationFile := out.(*validationfile.ValidationFile)
+		validationFile, ok := out.(*validationfile.ValidationFile)
+		if !ok {
+			return false, fmt.Errorf("could not cast unmarshalled file to validationfile")
+		}
 
 		// Need to join the original filepath with the requested filepath
 		// to construct the path to the referenced schema file.


### PR DESCRIPTION
Fixes #460 

## Description
This is something that broke in #455 because the interfaces didn't line up. This fixes the behavior of `zed import`.

## Changes
* Pass in the correct type in the import command's invocation of `decodeUrl`
* Add some defensiveness to the unmarshal logic so that it doesn't panic
* Add a test for the happy path that exercised the failure
## Testing
Review. Do a `go run ./cmd/zed/... import path/to/some/validationfile.yaml` and see that it either succeeds or fails on the gRPC call (if you aren't running a SpiceDB instance) rather than panicking on the parsing.