### PR TITLE
workflow: perms updated

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,8 @@ env:
 permissions:
   contents: "write"
   pull-requests: "write"
+  actions: "write"
+  repository-projects: "write"
 
 jobs:
   sync-docs:


### PR DESCRIPTION
I used these perms while debugging the same 403 with an earlier approach, `peter-evans/create-pull-request` action didn't need these perms on my fork (something to do with gh token), should work this time, checked with this just now https://github.com/kartikaysaxena/zed/actions/runs/13248365111/workflow