### PR TITLE
Add support for composable schemas in `zed validate`

### DIFF
--- a/internal/cmd/validate-test/composable-schema-root.zed
+++ b/internal/cmd/validate-test/composable-schema-root.zed
@@ -1,0 +1,6 @@
+import "./composable-schema-user.zed"
+
+definition resource {
+  relation user: user
+  permission view = user
+}

--- a/internal/cmd/validate-test/composable-schema-user.zed
+++ b/internal/cmd/validate-test/composable-schema-user.zed
@@ -1,0 +1,1 @@
+definition user {}

--- a/internal/cmd/validate-test/composable-schema-warning-root.zed
+++ b/internal/cmd/validate-test/composable-schema-warning-root.zed
@@ -1,0 +1,7 @@
+partial edit_partial {
+    permission edit = edit
+}
+
+definition resource {
+    ...edit_partial
+}

--- a/internal/cmd/validate-test/external-and-composable.yaml
+++ b/internal/cmd/validate-test/external-and-composable.yaml
@@ -1,0 +1,9 @@
+---
+schemaFile: "./composable-schema-root.zed"
+relationships: >-
+  resource:1#user@user:1
+assertions:
+  assertTrue:
+    - "resource:1#user@user:1"
+  assertFalse:
+    - "resource:1#user@user:2"

--- a/internal/cmd/validate-test/only-passes-composable.zed
+++ b/internal/cmd/validate-test/only-passes-composable.zed
@@ -1,0 +1,5 @@
+partial foo {}
+
+definition bar {
+  ...foo
+}

--- a/internal/decode/decoder_test.go
+++ b/internal/decode/decoder_test.go
@@ -165,7 +165,7 @@ schema:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			block := validationfile.ValidationFile{}
-			isOnlySchema, err := unmarshalAsYAMLOrSchema(tt.in, &block)
+			isOnlySchema, err := unmarshalAsYAMLOrSchema("", tt.in, &block)
 			require.Equal(t, tt.wantErr, err != nil)
 			require.Equal(t, tt.isOnlySchema, isOnlySchema)
 			if !tt.wantErr {


### PR DESCRIPTION
## Description
Part of composable schema support. We want to make it so that `zed validate` can operate on both composable schemas and standard schemas.

## Changes

* By default, `validate` will attempt to validate a schema first according to composable schema rules, then standard schema rules, and if both fail it will show the errors from composable schema.
* There's a new flag: `schema-syntax`. If you add `--schema-syntax composable`, it will validate according to only composable schema syntax rules, and if you add `--schema-syntax standard`, it will validate according to only standard schema rules. The default value for this flag is the empty string.

## Testing
- Manual testing to ensure no regressions were introduced
- Unit tests