### PR TITLE
goreleaser: add goreleaser config for publishing to chocolatey

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,37 @@
+---
+name: "Release for Windows"
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+permissions:
+  contents: "write"
+  packages: "write"
+jobs:
+  release-windows:
+    runs-on: "windows-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          fetch-depth: 0
+      - uses: "authzed/actions/setup-go@main"
+      - uses: "nowsprinting/check-version-format-action@v4"
+        id: "version"
+        with:
+          prefix: "v"
+      - uses: "authzed/actions/docker-login@main"
+        with:
+          quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          dockerhub_token: "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}"
+      - uses: "goreleaser/goreleaser-action@v6"
+        with:
+          distribution: "goreleaser-pro"
+          # NOTE: keep in sync with goreleaser version in other job.
+          # github actions don't allow yaml anchors.
+          version: "v2.3.2"
+          args: "release --clean --config=.goreleaser.windows.yml"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
+          CHOCOLATEY_API_KEY: "${{ secrets.CHOCOLATEY_API_KEY }}"

--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -1,0 +1,50 @@
+---
+version: 2
+git:
+  tag_sort: "-version:creatordate"
+  prerelease_suffix: "-"
+builds:
+  - main: "./cmd/zed"
+    env:
+      - "CGO_ENABLED=0"
+    goos:
+      - "windows"
+    goarch:
+      - "amd64"
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    ldflags:
+      - "-s -w"
+      - "-X github.com/jzelinskie/cobrautil/v2.Version=v{{ .Version }}"
+archives:
+  - files:
+      - "README.md"
+      - "LICENSE"
+    format_overrides:
+      - goos: "windows"
+        formats: ["zip"]
+
+chocolateys:
+  - name: "zed"
+    package_source_url: "https://github.com/authzed/zed"
+    owners: "AuthZed, Inc"
+    title: "Zed"
+    project_url: "https://github.com/authzed/zed"
+    url_template: "https://github.com/authzed/zed/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    icon_url: "https://authzed.com/favicon.svg"
+    copyright: "2025 AuthZed Inc."
+    authors: "Zed Contributors"
+    license_url: "https://github.com/authzed/zed/blob/main/LICENSE"
+    project_source_url: "https://github.com/authzed/zed"
+    docs_url: "https://authzed.com/docs"
+    bug_tracker_url: "https://github.com/authzed/zed/issues"
+    tags: "spicedb zanzibar authz rebac rbac abac fga cli command-line-tool"
+    summary: "Official command-line tool for managing SpiceDB"
+    description: |
+      Open Source command-line client for managing SpiceDB clusters, built by AuthZed.
+    release_notes: "https://github.com/authzed/zed/releases/tag/v{{ .Version }}"
+    api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
+    source_repo: "https://push.chocolatey.org/"
+checksum:
+  name_template: "windows_checksums.txt"
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"


### PR DESCRIPTION
Should close #480

Added goreleaser config for windows (similar to that of SpiceDB) with options for chocolatey.
Tested with `goreleaser release --snapshot --clean -f .goreleaser.windows.yml` for a snapshot build which generates chocolatey build files under `dist/`