### PR TITLE
perms: add support for cursor and show-cursor flags in lookup subjects

### DIFF
--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -107,6 +107,8 @@ func RegisterPermissionCmd(rootCmd *cobra.Command) *cobra.Command {
 	lookupResourcesCmd.Flags().String("revision", "", "optional revision at which to check")
 	lookupResourcesCmd.Flags().String("caveat-context", "", "the caveat context to send along with the lookup, in JSON form")
 	lookupResourcesCmd.Flags().Uint32("page-limit", 0, "limit of relations returned per page")
+	lookupResourcesCmd.Flags().String("cursor", "", "resume pagination from a specific cursor token")
+	lookupResourcesCmd.Flags().Bool("show-cursor", false, "display the cursor token after each page")
 	registerConsistencyFlags(lookupResourcesCmd.Flags())
 
 	permissionCmd.AddCommand(lookupSubjectsCmd)
@@ -461,6 +463,10 @@ func lookupResourcesCmdFunc(cmd *cobra.Command, args []string) error {
 	}
 
 	var cursor *v1.Cursor
+	if cursorStr := cobrautil.MustGetString(cmd, "cursor"); cursorStr != "" {
+		cursor = &v1.Cursor{Token: cursorStr}
+	}
+
 	var totalCount uint
 	for {
 		request := &v1.LookupResourcesRequest{
@@ -519,6 +525,11 @@ func lookupResourcesCmdFunc(cmd *cobra.Command, args []string) error {
 			log.Trace().Interface("request", request).Uint32("page-limit", pageLimit).Uint("count", totalCount).Send()
 			break
 		}
+	}
+
+	showCursor := cobrautil.MustGetBool(cmd, "show-cursor")
+	if showCursor && cursor != nil {
+		console.Printf("Last cursor: %s\n", cursor.Token)
 	}
 
 	return nil

--- a/internal/commands/permission_test.go
+++ b/internal/commands/permission_test.go
@@ -192,5 +192,7 @@ func testLookupResourcesCommand(t *testing.T, limit uint32) *cobra.Command {
 		zedtesting.StringFlag{FlagName: "revision"},
 		zedtesting.StringFlag{FlagName: "caveat-context"},
 		zedtesting.UintFlag32{FlagName: "page-limit", FlagValue: limit},
-		zedtesting.BoolFlag{FlagName: "json"})
+		zedtesting.BoolFlag{FlagName: "json"},
+		zedtesting.StringFlag{FlagName: "cursor"},
+		zedtesting.BoolFlag{FlagName: "show-cursor", FlagValue: false})
 }


### PR DESCRIPTION
Related #482

Adds support for displaying the last cursor when the user opts in a `show-cursor`, also allows user to use a custom cursor to resume browsing the pages from a specific state