### PR TITLE
add gci and usetesting linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,11 +4,14 @@ linters:
   enable:
     - "bidichk"
     - "bodyclose"
+    - "errcheck"
     - "errname"
     - "errorlint"
     - "goprintffuncname"
     - "gosec"
+    - "govet"
     - "importas"
+    - "ineffassign"
     - "makezero"
     - "prealloc"
     - "predeclared"
@@ -17,6 +20,8 @@ linters:
     - "rowserrcheck"
     - "staticcheck"
     - "unconvert"
+    - "unused"
+    - "usetesting"
     - "wastedassign"
     - "whitespace"
   exclusions:
@@ -32,9 +37,16 @@ linters:
       - "examples$"
 formatters:
   enable:
+    - "gci"
     - "gofumpt"
     - "goimports"
   settings:
+    gci:
+      sections:
+        - "standard"
+        - "default"
+        - "prefix(github.com/authzed)"
+        - "localmodule"
     goimports:
       local-prefixes:
         - "github.com/authzed/zed"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,17 +9,17 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/net/proxy"
-
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/authzed-go/v1"
-	"github.com/authzed/grpcutil"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/mitchellh/go-homedir"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"golang.org/x/net/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/authzed-go/v1"
+	"github.com/authzed/grpcutil"
 
 	zgrpcutil "github.com/authzed/zed/internal/grpcutil"
 	"github.com/authzed/zed/internal/storage"

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -5,16 +5,16 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/storage"
 	zedtesting "github.com/authzed/zed/internal/testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetTokenWithCLIOverride(t *testing.T) {
 	require := require.New(t)
-	testCert, err := os.CreateTemp("", "")
+	testCert, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(err)
 	_, err = testCert.Write([]byte("hi"))
 	require.NoError(err)
@@ -100,10 +100,9 @@ func TestGetCurrentTokenWithCLIOverrideWithoutSecretFile(t *testing.T) {
 
 	bTrue := true
 
-	tmpDir, err := os.MkdirTemp("", "")
-	require.NoError(err)
+	tmpDir := t.TempDir()
 	configPath := path.Join(tmpDir, "config.json")
-	err = os.WriteFile(configPath, []byte("{}"), 0o600)
+	err := os.WriteFile(configPath, []byte("{}"), 0o600)
 	require.NoError(err)
 
 	configStore := &storage.JSONConfigStore{ConfigPath: tmpDir}

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -11,11 +11,6 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
-	"github.com/authzed/spicedb/pkg/schemadsl/generator"
-	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/typesystem"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/mattn/go-isatty"
 	"github.com/rodaine/table"
@@ -25,6 +20,12 @@ import (
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/schemadsl/generator"
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/typesystem"
 
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/commands"

--- a/internal/cmd/backup_test.go
+++ b/internal/cmd/backup_test.go
@@ -8,14 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/google/uuid"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/require"
 
 	"github.com/authzed/zed/internal/client"
 	zedtesting "github.com/authzed/zed/internal/testing"
@@ -168,7 +168,7 @@ func TestBackupParseRelsCmdFunc(t *testing.T) {
 
 			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t, zedtesting.StringFlag{FlagName: "prefix-filter", FlagValue: tt.filter})
 			backupName := createTestBackup(t, tt.schema, tt.relationships)
-			f, err := os.CreateTemp("", "parse-output")
+			f, err := os.CreateTemp(t.TempDir(), "parse-output")
 			require.NoError(t, err)
 			defer func() {
 				_ = f.Close()
@@ -189,7 +189,7 @@ func TestBackupParseRelsCmdFunc(t *testing.T) {
 func TestBackupParseRevisionCmdFunc(t *testing.T) {
 	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t, zedtesting.StringFlag{FlagName: "prefix-filter", FlagValue: "test"})
 	backupName := createTestBackup(t, testSchema, testRelationships)
-	f, err := os.CreateTemp("", "parse-output")
+	f, err := os.CreateTemp(t.TempDir(), "parse-output")
 	require.NoError(t, err)
 	defer func() {
 		_ = f.Close()
@@ -249,7 +249,7 @@ func TestBackupParseSchemaCmdFunc(t *testing.T) {
 				zedtesting.StringFlag{FlagName: "prefix-filter", FlagValue: tt.filter},
 				zedtesting.BoolFlag{FlagName: "rewrite-legacy", FlagValue: tt.rewriteLegacy})
 			backupName := createTestBackup(t, tt.schema, nil)
-			f, err := os.CreateTemp("", "parse-output")
+			f, err := os.CreateTemp(t.TempDir(), "parse-output")
 			require.NoError(t, err)
 			defer func() {
 				_ = f.Close()

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -5,10 +5,11 @@ import (
 	"os"
 	"testing"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 
 	"github.com/authzed/zed/pkg/backupformat"
 )
@@ -42,7 +43,7 @@ func readLines(t *testing.T, fileName string) []string {
 func createTestBackup(t *testing.T, schema string, relationships []string) string {
 	t.Helper()
 
-	f, err := os.CreateTemp("", "test-backup")
+	f, err := os.CreateTemp(t.TempDir(), "test-backup")
 	require.NoError(t, err)
 	defer f.Close()
 	t.Cleanup(func() {

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -7,12 +7,13 @@ import (
 	"net/url"
 	"strings"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/authzed/spicedb/pkg/validationfile"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+	"github.com/authzed/spicedb/pkg/validationfile"
 
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/decode"

--- a/internal/cmd/import_test.go
+++ b/internal/cmd/import_test.go
@@ -5,8 +5,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/zed/internal/client"
 	zedtesting "github.com/authzed/zed/internal/testing"

--- a/internal/cmd/preview.go
+++ b/internal/cmd/preview.go
@@ -6,15 +6,16 @@ import (
 	"os"
 	"path/filepath"
 
-	newcompiler "github.com/authzed/spicedb/pkg/composableschemadsl/compiler"
-	newinput "github.com/authzed/spicedb/pkg/composableschemadsl/input"
-	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
-	"github.com/authzed/spicedb/pkg/schemadsl/generator"
 	"github.com/ccoveille/go-safecast"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	newcompiler "github.com/authzed/spicedb/pkg/composableschemadsl/compiler"
+	newinput "github.com/authzed/spicedb/pkg/composableschemadsl/input"
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/schemadsl/generator"
 
 	"github.com/authzed/zed/internal/commands"
 )

--- a/internal/cmd/restorer.go
+++ b/internal/cmd/restorer.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/ccoveille/go-safecast"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/mattn/go-isatty"
@@ -18,6 +16,9 @@ import (
 	"github.com/schollz/progressbar/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/spiceerrors"
 
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/console"

--- a/internal/cmd/restorer_test.go
+++ b/internal/cmd/restorer_test.go
@@ -6,14 +6,15 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/ccoveille/go-safecast"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 
 	"github.com/authzed/zed/internal/client"
 )

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -8,17 +8,18 @@ import (
 	"os"
 	"strings"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/diff"
-	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
-	"github.com/authzed/spicedb/pkg/schemadsl/generator"
-	"github.com/authzed/spicedb/pkg/schemadsl/input"
 	"github.com/ccoveille/go-safecast"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/diff"
+	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
+	"github.com/authzed/spicedb/pkg/schemadsl/generator"
+	"github.com/authzed/spicedb/pkg/schemadsl/input"
 
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/commands"

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 
 	"github.com/ccoveille/go-safecast"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/jzelinskie/cobrautil/v2"
+	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 
 	"github.com/authzed/spicedb/pkg/development"
@@ -15,9 +18,6 @@ import (
 	devinterface "github.com/authzed/spicedb/pkg/proto/developer/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/validationfile"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/jzelinskie/cobrautil/v2"
-	"github.com/muesli/termenv"
 
 	"github.com/authzed/zed/internal/commands"
 	"github.com/authzed/zed/internal/console"

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/authzed/authzed-go/pkg/responsemeta"
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/gookit/color"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/authzed/authzed-go/pkg/responsemeta"
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/console"

--- a/internal/commands/completion.go
+++ b/internal/commands/completion.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
-	"github.com/spf13/cobra"
 
 	"github.com/authzed/zed/internal/client"
 )

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -7,11 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/authzed/spicedb/pkg/tuple"
-
-	"github.com/authzed/authzed-go/pkg/requestmeta"
-	"github.com/authzed/authzed-go/pkg/responsemeta"
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
@@ -21,6 +16,11 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
+
+	"github.com/authzed/authzed-go/pkg/requestmeta"
+	"github.com/authzed/authzed-go/pkg/responsemeta"
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/console"

--- a/internal/commands/permission_test.go
+++ b/internal/commands/permission_test.go
@@ -5,11 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/authzed/spicedb/pkg/tuple"
-
-	"github.com/authzed/zed/internal/console"
-	zedtesting "github.com/authzed/zed/internal/testing"
-
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
@@ -19,8 +14,11 @@ import (
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
+	"github.com/authzed/spicedb/pkg/tuple"
 
 	"github.com/authzed/zed/internal/client"
+	"github.com/authzed/zed/internal/console"
+	zedtesting "github.com/authzed/zed/internal/testing"
 )
 
 func init() {

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -11,11 +11,6 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/authzed/zed/internal/client"
-	"github.com/authzed/zed/internal/console"
-
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
@@ -23,6 +18,12 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+
+	"github.com/authzed/zed/internal/client"
+	"github.com/authzed/zed/internal/console"
 )
 
 func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -9,17 +9,18 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/authzed/zed/internal/client"
-	zedtesting "github.com/authzed/zed/internal/testing"
-
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
+
+	"github.com/authzed/zed/internal/client"
+	zedtesting "github.com/authzed/zed/internal/testing"
 )
 
 const testSchema = `definition test/resource {
@@ -210,7 +211,7 @@ func TestParseRelationshipLine(t *testing.T) {
 }
 
 func TestWriteRelationshipsArgs(t *testing.T) {
-	f, err := os.CreateTemp("", "spicedb-")
+	f, err := os.CreateTemp(t.TempDir(), "spicedb-")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -258,7 +259,7 @@ func TestWriteRelationshipCmdFuncFromTTY(t *testing.T) {
 		isFileTerminal = originalFunc
 	}()
 
-	tty, err := os.CreateTemp("", "spicedb-")
+	tty, err := os.CreateTemp(t.TempDir(), "spicedb-")
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -567,7 +568,7 @@ func TestWriteRelationshipCmdFuncFromStdinBatchWithExpirationTime(t *testing.T) 
 func fileFromStrings(t *testing.T, strings []string) *os.File {
 	t.Helper()
 
-	fi, err := os.CreateTemp("", "spicedb-")
+	fi, err := os.CreateTemp(t.TempDir(), "spicedb-")
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, fi.Close())

--- a/internal/commands/schema.go
+++ b/internal/commands/schema.go
@@ -3,13 +3,14 @@ package commands
 import (
 	"context"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
 	"github.com/authzed/zed/internal/client"
 	"github.com/authzed/zed/internal/console"

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 
 	"github.com/TylerBrock/colorjson"
-	"github.com/authzed/authzed-go/pkg/requestmeta"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/authzed/authzed-go/pkg/requestmeta"
 )
 
 // ParseSubject parses the given subject string into its namespace, object ID

--- a/internal/commands/watch.go
+++ b/internal/commands/watch.go
@@ -9,11 +9,12 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/authzed/zed/internal/client"
-	"github.com/authzed/zed/internal/console"
+	"github.com/spf13/cobra"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/spf13/cobra"
+
+	"github.com/authzed/zed/internal/client"
+	"github.com/authzed/zed/internal/console"
 )
 
 var (

--- a/internal/decode/decoder.go
+++ b/internal/decode/decoder.go
@@ -12,13 +12,14 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+
 	"github.com/authzed/spicedb/pkg/schemadsl/compiler"
 	"github.com/authzed/spicedb/pkg/schemadsl/input"
 	"github.com/authzed/spicedb/pkg/spiceerrors"
 	"github.com/authzed/spicedb/pkg/validationfile"
 	"github.com/authzed/spicedb/pkg/validationfile/blocks"
-	"github.com/rs/zerolog/log"
-	"gopkg.in/yaml.v3"
 )
 
 var playgroundPattern = regexp.MustCompile("^.*/s/.*/schema|relationships|assertions|expected.*$")

--- a/internal/decode/decoder_test.go
+++ b/internal/decode/decoder_test.go
@@ -4,8 +4,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/authzed/spicedb/pkg/validationfile"
 	"github.com/stretchr/testify/require"
+
+	"github.com/authzed/spicedb/pkg/validationfile"
 )
 
 func TestRewriteURL(t *testing.T) {

--- a/internal/grpcutil/grpcutil.go
+++ b/internal/grpcutil/grpcutil.go
@@ -7,13 +7,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/authzed/authzed-go/pkg/requestmeta"
-	"github.com/authzed/authzed-go/pkg/responsemeta"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/mod/semver"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/authzed/authzed-go/pkg/requestmeta"
+	"github.com/authzed/authzed-go/pkg/responsemeta"
 	"github.com/authzed/spicedb/pkg/releases"
 )
 

--- a/internal/printers/debug.go
+++ b/internal/printers/debug.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gookit/color"
+
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/spicedb/pkg/tuple"
-	"github.com/gookit/color"
 )
 
 // DisplayCheckTrace prints out the check trace found in the given debug message.

--- a/internal/printers/tree.go
+++ b/internal/printers/tree.go
@@ -3,8 +3,9 @@ package printers
 import (
 	"fmt"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/jzelinskie/stringz"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
 func prettySubject(subj *v1.SubjectReference) string {

--- a/internal/printers/treeprinter.go
+++ b/internal/printers/treeprinter.go
@@ -3,9 +3,9 @@ package printers
 import (
 	"strings"
 
-	"github.com/authzed/zed/internal/console"
-
 	"github.com/xlab/treeprint"
+
+	"github.com/authzed/zed/internal/console"
 )
 
 type TreePrinter struct {

--- a/internal/testing/test_helpers.go
+++ b/internal/testing/test_helpers.go
@@ -5,14 +5,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
 	"github.com/authzed/spicedb/pkg/cmd/datastore"
 	"github.com/authzed/spicedb/pkg/cmd/server"
 	"github.com/authzed/spicedb/pkg/cmd/util"
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 
 	"github.com/authzed/zed/internal/client"
 )

--- a/pkg/backupformat/backupformat_test.go
+++ b/pkg/backupformat/backupformat_test.go
@@ -5,10 +5,11 @@ import (
 	"encoding/base64"
 	"testing"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
 func TestWriteAndRead(t *testing.T) {

--- a/pkg/backupformat/decoder.go
+++ b/pkg/backupformat/decoder.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"io"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/hamba/avro/v2"
 	"github.com/hamba/avro/v2/ocf"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
 func init() {

--- a/pkg/backupformat/encoder.go
+++ b/pkg/backupformat/encoder.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"io"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/hamba/avro/v2/ocf"
 	"google.golang.org/protobuf/proto"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
 func NewEncoder(w io.Writer, schema string, token *v1.ZedToken) (*Encoder, error) {

--- a/pkg/backupformat/redaction_test.go
+++ b/pkg/backupformat/redaction_test.go
@@ -6,10 +6,11 @@ import (
 	"io"
 	"testing"
 
-	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
-	"github.com/authzed/spicedb/pkg/tuple"
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
+
+	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 )
 
 func TestRedactSchema(t *testing.T) {


### PR DESCRIPTION
I'm bringing over some changes made in https://github.com/authzed/zed/pull/478, plus adding more linters

## Testing

```
[15:14:00] ~/Documents/GitHub/zed (linters) $ golangci-lint run -v --fix -c .golangci.yaml ./...
INFO golangci-lint has version v2.1.2 built with go1.24.1 from (unknown, modified: ?, mod sum: "h1:bcOB+jVr4EYEgOEIskQIhtdxOpIGl+iOCwliG/hNPXw=") on (unknown) 
INFO [config_reader] Used config file .golangci.yaml 
INFO maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined 
INFO [goenv] Read go env for 5.80425ms: map[string]string{"GOCACHE":"/Users/miparnisari/Library/Caches/go-build", "GOROOT":"/usr/local/go"} 
INFO [lintersdb] Active 25 linters: [bidichk bodyclose errcheck errname errorlint gci gofumpt goimports goprintffuncname gosec govet importas ineffassign makezero prealloc predeclared promlinter revive rowserrcheck staticcheck unconvert unused usetesting wastedassign whitespace] 
INFO [loader] Go packages loading at mode 8767 (types_sizes|files|compiled_files|deps|exports_file|imports|name) took 853.91225ms 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 2.14725ms 
INFO [linters_context] importas settings found, but no aliases listed. List aliases under alias: key. 
INFO [linters_context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Applying suggested fixes            
INFO [runner] fixer took 667ns with stages: all: 667ns 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "third_party$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "builtin$" 
INFO [runner/exclusion_paths] Skipped 0 issues by pattern "examples$" 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "third_party$", Linters: "gci, gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "builtin$", Linters: "gci, gofumpt, goimports"] 
INFO [runner/exclusion_rules] Skipped 0 issues by rules: [Path: "examples$", Linters: "gci, gofumpt, goimports"] 
INFO [runner] Issues before processing: 90, after processing: 0 
INFO [runner] Processors filtering stat (in/out): exclusion_rules: 90/0, cgo: 90/90, filename_unadjuster: 90/90, path_relativity: 90/90, generated_file_filter: 90/90, invalid_issue: 90/90, exclusion_paths: 90/90, path_absoluter: 90/90 
INFO [runner] processing took 564.96µs with stages: generated_file_filter: 357.042µs, exclusion_rules: 129.042µs, path_relativity: 28.916µs, exclusion_paths: 21.667µs, fixer: 11µs, cgo: 6.875µs, invalid_issue: 4.041µs, sort_results: 2µs, path_absoluter: 1.375µs, filename_unadjuster: 1.251µs, nolint_filter: 501ns, max_same_issues: 416ns, source_code: 209ns, path_shortener: 166ns, path_prettifier: 126ns, max_from_linter: 125ns, diff: 83ns, uniq_by_line: 42ns, severity-rules: 42ns, max_per_file_from_linter: 41ns 
INFO [runner] linters took 527.56975ms with stages: goanalysis_metalinter: 526.944541ms 
0 issues.
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 15 samples, avg is 55.4MB, max is 89.1MB 
INFO Execution took 1.395726667s                  
[15:15:25] ~/Documents/GitHub/zed (linters) $ 
```