### PR TITLE
introduce resumable backups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/authzed/zed
 
-go 1.23.8
+go 1.24
 
 toolchain go1.24.1
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -162,7 +162,9 @@ func tokenFromCli(cmd *cobra.Command) (storage.Token, error) {
 }
 
 // DefaultStorage returns the default configured config store and secret store.
-func DefaultStorage() (storage.ConfigStore, storage.SecretStore) {
+var DefaultStorage = defaultStorage
+
+func defaultStorage() (storage.ConfigStore, storage.SecretStore) {
 	var home string
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		home = filepath.Join(xdg, "zed")

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -101,6 +101,8 @@ func registerBackupCmd(rootCmd *cobra.Command) {
 	backupCmd.AddCommand(backupCreateCmd)
 	registerBackupCreateFlags(backupCreateCmd)
 
+	backupCreateCmd.Flags().Uint32("page-limit", 0, "include only schema and relationships with a given prefix")
+
 	backupCmd.AddCommand(backupRestoreCmd)
 	registerBackupRestoreFlags(backupRestoreCmd)
 
@@ -256,6 +258,8 @@ func backupCreateCmdFunc(cmd *cobra.Command, args []string) (err error) {
 		backupFileName = args[0]
 	}
 
+	pageLimit := cobrautil.MustGetUint32(cmd, "page-limit")
+
 	f, err := createBackupFile(backupFileName)
 	if err != nil {
 		return err
@@ -300,6 +304,7 @@ func backupCreateCmdFunc(cmd *cobra.Command, args []string) (err error) {
 	defer func(e *error) { *e = errors.Join(*e, encoder.Close()) }(&err)
 
 	relationshipStream, err := c.BulkExportRelationships(ctx, &v1.BulkExportRelationshipsRequest{
+		OptionalLimit: pageLimit,
 		Consistency: &v1.Consistency{
 			Requirement: &v1.Consistency_AtExactSnapshot{
 				AtExactSnapshot: schemaResp.ReadAt,

--- a/internal/cmd/import_test.go
+++ b/internal/cmd/import_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -27,8 +26,7 @@ func TestImportCmdHappyPath(t *testing.T) {
 	f := filepath.Join("import-test", "happy-path-validation-file.yaml")
 
 	// Set up client
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
 		require.NoError(srv.Run(ctx))

--- a/internal/cmd/restorer_test.go
+++ b/internal/cmd/restorer_test.go
@@ -157,7 +157,7 @@ func TestRestorer(t *testing.T) {
 			}
 
 			r := newRestorer(testSchema, d, c, tt.prefixFilter, tt.batchSize, tt.batchesPerTransaction, tt.conflictStrategy, tt.disableRetryErrors, 0*time.Second)
-			err = r.restoreFromDecoder(context.Background())
+			err = r.restoreFromDecoder(t.Context())
 			if expectsError != nil || (expectedConflicts > 0 && tt.conflictStrategy == Fail) {
 				require.ErrorIs(err, expectsError)
 				return

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -59,7 +58,7 @@ func TestDeterminePrefixForSchema(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			found, err := determinePrefixForSchema(context.Background(), test.specifiedPrefix, nil, &test.existingSchema)
+			found, err := determinePrefixForSchema(t.Context(), test.specifiedPrefix, nil, &test.existingSchema)
 			require.NoError(t, err)
 			require.Equal(t, test.expectedPrefix, found)
 		})

--- a/internal/commands/permission_test.go
+++ b/internal/commands/permission_test.go
@@ -103,7 +103,7 @@ func TestCheckErrorWithInvalidDebugInformation(t *testing.T) {
 }
 
 func TestLookupResourcesCommand(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -670,7 +670,7 @@ func (m *mockClient) WriteRelationships(_ context.Context, in *v1.WriteRelations
 }
 
 func TestBulkDeleteForcing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
@@ -720,7 +720,7 @@ func TestBulkDeleteForcing(t *testing.T) {
 }
 
 func TestBulkDeleteManyForcing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
@@ -762,7 +762,7 @@ func TestBulkDeleteManyForcing(t *testing.T) {
 }
 
 func TestBulkDeleteNotForcing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {

--- a/internal/grpcutil/batch_test.go
+++ b/internal/grpcutil/batch_test.go
@@ -67,7 +67,7 @@ func TestConcurrentBatchOrdering(t *testing.T) {
 				return nil
 			}
 
-			err := ConcurrentBatch(context.Background(), len(tt.items), batchSize, workers, fn)
+			err := ConcurrentBatch(t.Context(), len(tt.items), batchSize, workers, fn)
 			require.NoError(err)
 
 			got := make([]batch, len(gotCh))
@@ -133,7 +133,7 @@ func TestConcurrentBatch(t *testing.T) {
 				atomic.AddInt64(&calls, 1)
 				return nil
 			}
-			err := ConcurrentBatch(context.Background(), len(tt.items), tt.batchSize, tt.workers, fn)
+			err := ConcurrentBatch(t.Context(), len(tt.items), tt.batchSize, tt.workers, fn)
 
 			require.NoError(err)
 			require.Equal(tt.wantCalls, int(calls))

--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -69,7 +69,7 @@ type SecretStore interface {
 	Put(s Secrets) error
 }
 
-// Returns an empty token if no token exists.
+// GetTokenIfExists returns an empty token if no token exists.
 func GetTokenIfExists(name string, ss SecretStore) (Token, error) {
 	secrets, err := ss.Get()
 	if err != nil {

--- a/internal/testing/test_helpers.go
+++ b/internal/testing/test_helpers.go
@@ -127,6 +127,6 @@ func CreateTestCobraCommandWithFlagValue(t *testing.T, flagAndValues ...any) *co
 		}
 	}
 
-	c.SetContext(context.Background())
+	c.SetContext(t.Context())
 	return &c
 }

--- a/pkg/backupformat/encoder.go
+++ b/pkg/backupformat/encoder.go
@@ -11,6 +11,20 @@ import (
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 )
 
+func NewEncoderForExisting(w io.Writer) (*Encoder, error) {
+	avroSchema, err := avroSchemaV1()
+	if err != nil {
+		return nil, fmt.Errorf("unable to create avro schema: %w", err)
+	}
+
+	enc, err := ocf.NewEncoder(avroSchema, w, ocf.WithCodec(ocf.Snappy))
+	if err != nil {
+		return nil, fmt.Errorf("unable to create encoder: %w", err)
+	}
+
+	return &Encoder{enc}, nil
+}
+
 func NewEncoder(w io.Writer, schema string, token *v1.ZedToken) (*Encoder, error) {
 	avroSchema, err := avroSchemaV1()
 	if err != nil {


### PR DESCRIPTION
This PR modifies the backup create command to allow an incomplete backup to be resumed.

A new marker file is added with the last written bulk export cursor. This was not added to the OCF file because OCF container is not meant for in-place updates, but streaming append operations. The marker is updated every time a bulk export page is successfully written.

For convenience, the command now also supports creating a backup without a file name; in this case, it will derive the backup file name from the Zed context name. A new `page-limit` flag has also been added to allow users to specify the number of relationships to ingest per page. This may be useful as a mechanism to throttle the number of relationships read from the datastore.

The new logic detects several scenarios like:
- A backup exists, but no marker exists (meaning it has completed)
- Backup does not exist, but the marker is left behind (it gets truncated)

The marker file will be removed only when the backup completes.

This new logic does not guarantee that relationships will not be duplicated. When terminated gracefully, the system should write the last page received, close, and flush the files. But if the process was abruptly terminated (i.e. SIGKILL) it could lead to relationships being written to the OCF file, but the marker not being updated.