### PR TITLE
print usage only on parse/validation errors

### DIFF
--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -53,7 +53,7 @@ var (
 	backupCmd = &cobra.Command{
 		Use:   "backup <filename>",
 		Short: "Create, restore, and inspect permissions system backups",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  commands.ValidationWrapper(cobra.MaximumNArgs(1)),
 		// Create used to be on the root, so add it here for back-compat.
 		RunE: withErrorHandling(backupCreateCmdFunc),
 	}
@@ -61,21 +61,21 @@ var (
 	backupCreateCmd = &cobra.Command{
 		Use:   "create <filename>",
 		Short: "Backup a permission system to a file",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  commands.ValidationWrapper(cobra.MaximumNArgs(1)),
 		RunE:  withErrorHandling(backupCreateCmdFunc),
 	}
 
 	backupRestoreCmd = &cobra.Command{
 		Use:   "restore <filename>",
 		Short: "Restore a permission system from a file",
-		Args:  commands.StdinOrExactArgs(1),
+		Args:  commands.ValidationWrapper(commands.StdinOrExactArgs(1)),
 		RunE:  backupRestoreCmdFunc,
 	}
 
 	backupParseSchemaCmd = &cobra.Command{
 		Use:   "parse-schema <filename>",
 		Short: "Extract the schema from a backup file",
-		Args:  cobra.ExactArgs(1),
+		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return backupParseSchemaCmdFunc(cmd, os.Stdout, args)
 		},
@@ -84,7 +84,7 @@ var (
 	backupParseRevisionCmd = &cobra.Command{
 		Use:   "parse-revision <filename>",
 		Short: "Extract the revision from a backup file",
-		Args:  cobra.ExactArgs(1),
+		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return backupParseRevisionCmdFunc(cmd, os.Stdout, args)
 		},
@@ -93,7 +93,7 @@ var (
 	backupParseRelsCmd = &cobra.Command{
 		Use:   "parse-relationships <filename>",
 		Short: "Extract the relationships from a backup file",
-		Args:  cobra.ExactArgs(1),
+		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return backupParseRelsCmdFunc(cmd, os.Stdout, args)
 		},
@@ -102,7 +102,7 @@ var (
 	backupRedactCmd = &cobra.Command{
 		Use:   "redact <filename>",
 		Short: "Redact a backup file to remove sensitive information",
-		Args:  cobra.ExactArgs(1),
+		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return backupRedactCmdFunc(cmd, args)
 		},
@@ -129,7 +129,7 @@ func registerBackupCmd(rootCmd *cobra.Command) {
 	restoreCmd := &cobra.Command{
 		Use:    "restore <filename>",
 		Short:  "Restore a permission system from a backup file",
-		Args:   cobra.MaximumNArgs(1),
+		Args:   commands.ValidationWrapper(cobra.MaximumNArgs(1)),
 		RunE:   backupRestoreCmdFunc,
 		Hidden: true,
 	}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+// note: these tests mess with global variables, so do not run in parallel with other tests.
+func TestCommandOutput(t *testing.T) {
+	cases := []struct {
+		name                  string
+		flagErrorContains     string
+		expectUsageContains   string
+		expectFlagErrorCalled bool
+		expectStdErrorMsg     string
+		command               []string
+	}{
+		{
+			name:                  "prints usage on invalid command error",
+			command:               []string{"zed", "madeupcommand"},
+			expectFlagErrorCalled: true,
+			flagErrorContains:     "unknown command",
+			expectUsageContains:   "zed [command]",
+		},
+		{
+			name:                  "prints usage on invalid flag error",
+			command:               []string{"zed", "version", "--madeupflag"},
+			expectFlagErrorCalled: true,
+			flagErrorContains:     "unknown flag: --madeupflag",
+			expectUsageContains:   "zed version [flags]",
+		},
+		{
+			name:                  "prints usage on parameter validation error",
+			command:               []string{"zed", "validate"},
+			expectFlagErrorCalled: true,
+			flagErrorContains:     "requires at least 1 arg(s), only received 0",
+			expectUsageContains:   "zed validate <validation_file_or_schema_file> [flags]",
+		},
+		{
+			name:                  "prints correct usage",
+			command:               []string{"zed", "perm", "check"},
+			expectFlagErrorCalled: true,
+			flagErrorContains:     "accepts 3 arg(s), received 0",
+			expectUsageContains:   "zed permission check <resource:id> <permission> <subject:id>",
+		},
+		{
+			name:                  "does not print usage on command error",
+			command:               []string{"zed", "validate", uuid.NewString()},
+			expectFlagErrorCalled: false,
+			expectStdErrorMsg:     "terminated with errors",
+		},
+	}
+
+	zl := cobrazerolog.New(cobrazerolog.WithPreRunLevel(zerolog.DebugLevel))
+
+	rootCmd := InitialiseRootCmd(zl)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var flagErrorCalled bool
+			testFlagError := func(cmd *cobra.Command, err error) error {
+				require.ErrorContains(t, err, tt.flagErrorContains)
+				require.Contains(t, cmd.UsageString(), tt.expectUsageContains)
+				flagErrorCalled = true
+				return errParsing
+			}
+			stderrFile := setupOutputForTest(t, testFlagError, tt.command...)
+
+			err := handleError(rootCmd, rootCmd.ExecuteContext(t.Context()))
+			require.Error(t, err)
+			stdErrBytes, err := os.ReadFile(stderrFile)
+			require.NoError(t, err)
+			if tt.expectStdErrorMsg != "" {
+				require.Contains(t, string(stdErrBytes), tt.expectStdErrorMsg)
+			} else {
+				require.Len(t, stdErrBytes, 0)
+			}
+			require.Equal(t, tt.expectFlagErrorCalled, flagErrorCalled)
+		})
+	}
+}
+
+func setupOutputForTest(t *testing.T, testFlagError func(cmd *cobra.Command, err error) error, args ...string) string {
+	t.Helper()
+
+	originalLevel := zerolog.GlobalLevel()
+	originalFlagError := flagError
+	originalArgs := os.Args
+	originalStderr := os.Stderr
+	t.Cleanup(func() {
+		zerolog.SetGlobalLevel(originalLevel)
+		flagError = originalFlagError
+		os.Args = originalArgs
+		os.Stderr = originalStderr
+	})
+
+	if len(args) > 0 {
+		os.Args = args
+	}
+	flagError = testFlagError
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	tempStdErrFileName := filepath.Join(t.TempDir(), uuid.NewString())
+	tempStdErr, err := os.Create(tempStdErrFileName)
+	require.NoError(t, err)
+
+	os.Stderr = tempStdErr
+	return tempStdErrFileName
+}

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/authzed/zed/internal/client"
+	"github.com/authzed/zed/internal/commands"
 	"github.com/authzed/zed/internal/console"
 	"github.com/authzed/zed/internal/printers"
 	"github.com/authzed/zed/internal/storage"
@@ -35,7 +36,7 @@ var contextListCmd = &cobra.Command{
 	Use:               "list",
 	Short:             "Lists all available contexts",
 	Aliases:           []string{"ls"},
-	Args:              cobra.ExactArgs(0),
+	Args:              commands.ValidationWrapper(cobra.ExactArgs(0)),
 	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE:              contextListCmdFunc,
 }
@@ -43,7 +44,7 @@ var contextListCmd = &cobra.Command{
 var contextSetCmd = &cobra.Command{
 	Use:               "set <name> <endpoint> <api-token>",
 	Short:             "Creates or overwrite a context",
-	Args:              cobra.ExactArgs(3),
+	Args:              commands.ValidationWrapper(cobra.ExactArgs(3)),
 	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE:              contextSetCmdFunc,
 }
@@ -52,7 +53,7 @@ var contextRemoveCmd = &cobra.Command{
 	Use:               "remove <system>",
 	Short:             "Removes a context",
 	Aliases:           []string{"rm"},
-	Args:              cobra.ExactArgs(1),
+	Args:              commands.ValidationWrapper(cobra.ExactArgs(1)),
 	ValidArgsFunction: ContextGet,
 	RunE:              contextRemoveCmdFunc,
 }
@@ -60,7 +61,7 @@ var contextRemoveCmd = &cobra.Command{
 var contextUseCmd = &cobra.Command{
 	Use:               "use <system>",
 	Short:             "Sets a context as the current context",
-	Args:              cobra.MaximumNArgs(1),
+	Args:              commands.ValidationWrapper(cobra.MaximumNArgs(1)),
 	ValidArgsFunction: ContextGet,
 	RunE:              contextUseCmdFunc,
 }

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -16,6 +16,7 @@ import (
 	"github.com/authzed/spicedb/pkg/validationfile"
 
 	"github.com/authzed/zed/internal/client"
+	"github.com/authzed/zed/internal/commands"
 	"github.com/authzed/zed/internal/decode"
 	"github.com/authzed/zed/internal/grpcutil"
 )
@@ -60,7 +61,7 @@ var importCmd = &cobra.Command{
 	With schema definition prefix:
 		zed import --schema-definition-prefix=mypermsystem file:///Users/zed/Downloads/authzed-x7izWU8_2Gw3.yaml
 `,
-	Args: cobra.ExactArgs(1),
+	Args: commands.ValidationWrapper(cobra.ExactArgs(1)),
 	RunE: importCmdFunc,
 }
 

--- a/internal/cmd/preview.go
+++ b/internal/cmd/preview.go
@@ -41,7 +41,7 @@ var schemaCmd = &cobra.Command{
 
 var schemaCompileCmd = &cobra.Command{
 	Use:   "compile <file>",
-	Args:  cobra.ExactArgs(1),
+	Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
 	Short: "Compile a schema that uses extended syntax into one that can be written to SpiceDB",
 	Example: `
 	Write to stdout:

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -41,7 +41,7 @@ func registerAdditionalSchemaCmds(schemaCmd *cobra.Command) {
 
 var schemaWriteCmd = &cobra.Command{
 	Use:               "write <file?>",
-	Args:              cobra.MaximumNArgs(1),
+	Args:              commands.ValidationWrapper(cobra.MaximumNArgs(1)),
 	Short:             "Write a schema file (.zed or stdin) to the current permissions system",
 	ValidArgsFunction: commands.FileExtensionCompletions("zed"),
 	RunE:              schemaWriteCmdFunc,
@@ -50,7 +50,7 @@ var schemaWriteCmd = &cobra.Command{
 var schemaCopyCmd = &cobra.Command{
 	Use:               "copy <src context> <dest context>",
 	Short:             "Copy a schema from one context into another",
-	Args:              cobra.ExactArgs(2),
+	Args:              commands.ValidationWrapper(cobra.ExactArgs(2)),
 	ValidArgsFunction: ContextGet,
 	RunE:              schemaCopyCmdFunc,
 }
@@ -58,7 +58,7 @@ var schemaCopyCmd = &cobra.Command{
 var schemaDiffCmd = &cobra.Command{
 	Use:   "diff <before file> <after file>",
 	Short: "Diff two schema files",
-	Args:  cobra.ExactArgs(2),
+	Args:  commands.ValidationWrapper(cobra.ExactArgs(2)),
 	RunE:  schemaDiffCmdFunc,
 }
 

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -71,7 +71,7 @@ var validateCmd = &cobra.Command{
 
 	From a devtools instance:
 		zed validate https://localhost:8443/download`,
-	Args:              cobra.MinimumNArgs(1),
+	Args:              commands.ValidationWrapper(cobra.MinimumNArgs(1)),
 	ValidArgsFunction: commands.FileExtensionCompletions("zed", "yaml", "zaml"),
 	PreRunE:           validatePreRunE,
 	RunE: func(cmd *cobra.Command, filenames []string) error {

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -129,14 +129,14 @@ var permissionCmd = &cobra.Command{
 var checkBulkCmd = &cobra.Command{
 	Use:   "bulk <resource:id#permission@subject:id> <resource:id#permission@subject:id> ...",
 	Short: "Check a permissions in bulk exists for a resource-subject pairs",
-	Args:  cobra.MinimumNArgs(1),
+	Args:  ValidationWrapper(cobra.MinimumNArgs(1)),
 	RunE:  checkBulkCmdFunc,
 }
 
 var checkCmd = &cobra.Command{
 	Use:               "check <resource:id> <permission> <subject:id>",
 	Short:             "Check that a permission exists for a subject",
-	Args:              cobra.ExactArgs(3),
+	Args:              ValidationWrapper(cobra.ExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectID),
 	RunE:              checkCmdFunc,
 }
@@ -144,7 +144,7 @@ var checkCmd = &cobra.Command{
 var expandCmd = &cobra.Command{
 	Use:               "expand <permission> <resource:id>",
 	Short:             "Expand the structure of a permission",
-	Args:              cobra.ExactArgs(2),
+	Args:              ValidationWrapper(cobra.ExactArgs(2)),
 	ValidArgsFunction: cobra.NoFileCompletions,
 	RunE:              expandCmdFunc,
 }
@@ -152,7 +152,7 @@ var expandCmd = &cobra.Command{
 var lookupResourcesCmd = &cobra.Command{
 	Use:               "lookup-resources <type> <permission> <subject:id>",
 	Short:             "Enumerates resources of a given type for which the subject has permission",
-	Args:              cobra.ExactArgs(3),
+	Args:              ValidationWrapper(cobra.ExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
 	RunE:              lookupResourcesCmdFunc,
 }
@@ -160,7 +160,7 @@ var lookupResourcesCmd = &cobra.Command{
 var lookupCmd = &cobra.Command{
 	Use:               "lookup <type> <permission> <subject:id>",
 	Short:             "Enumerates the resources of a given type for which the subject has permission",
-	Args:              cobra.ExactArgs(3),
+	Args:              ValidationWrapper(cobra.ExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
 	RunE:              lookupResourcesCmdFunc,
 	Deprecated:        "prefer lookup-resources",
@@ -170,7 +170,7 @@ var lookupCmd = &cobra.Command{
 var lookupSubjectsCmd = &cobra.Command{
 	Use:               "lookup-subjects <resource:id> <permission> <subject_type#optional_subject_relation>",
 	Short:             "Enumerates the subjects of a given type for which the subject has permission on the resource",
-	Args:              cobra.ExactArgs(3),
+	Args:              ValidationWrapper(cobra.ExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              lookupSubjectsCmdFunc,
 }

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -70,7 +70,7 @@ var relationshipCmd = &cobra.Command{
 var createCmd = &cobra.Command{
 	Use:               "create <resource:id> <relation> <subject:id#optional_subject_relation>",
 	Short:             "Create a relationship for a subject",
-	Args:              StdinOrExactArgs(3),
+	Args:              ValidationWrapper(StdinOrExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_CREATE, os.Stdin),
 }
@@ -78,7 +78,7 @@ var createCmd = &cobra.Command{
 var touchCmd = &cobra.Command{
 	Use:               "touch <resource:id> <relation> <subject:id#optional_subject_relation>",
 	Short:             "Idempotently updates a relationship for a subject",
-	Args:              StdinOrExactArgs(3),
+	Args:              ValidationWrapper(StdinOrExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_TOUCH, os.Stdin),
 }
@@ -86,7 +86,7 @@ var touchCmd = &cobra.Command{
 var deleteCmd = &cobra.Command{
 	Use:               "delete <resource:id> <relation> <subject:id#optional_subject_relation>",
 	Short:             "Deletes a relationship",
-	Args:              StdinOrExactArgs(3),
+	Args:              ValidationWrapper(StdinOrExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_DELETE, os.Stdin),
 }
@@ -102,7 +102,7 @@ var readCmd = &cobra.Command{
 	Use:               "read <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation>",
 	Short:             "Enumerates relationships matching the provided pattern",
 	Long:              readCmdHelpLong,
-	Args:              cobra.RangeArgs(1, 3),
+	Args:              ValidationWrapper(cobra.RangeArgs(1, 3)),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              readRelationships,
 }
@@ -110,7 +110,7 @@ var readCmd = &cobra.Command{
 var bulkDeleteCmd = &cobra.Command{
 	Use:               "bulk-delete <resource_type:optional_resource_id> <optional_relation> <optional_subject_type:optional_subject_id#optional_subject_relation>",
 	Short:             "Deletes relationships matching the provided pattern en masse",
-	Args:              cobra.RangeArgs(1, 3),
+	Args:              ValidationWrapper(cobra.RangeArgs(1, 3)),
 	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 	RunE:              bulkDeleteRelationships,
 }

--- a/internal/commands/schema.go
+++ b/internal/commands/schema.go
@@ -34,7 +34,7 @@ var (
 	schemaReadCmd = &cobra.Command{
 		Use:               "read",
 		Short:             "Read the schema of a permissions system",
-		Args:              cobra.ExactArgs(0),
+		Args:              ValidationWrapper(cobra.ExactArgs(0)),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              schemaReadCmdFunc,
 	}

--- a/internal/commands/util_test.go
+++ b/internal/commands/util_test.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidationWrapper(t *testing.T) {
+	tests := []struct {
+		name           string
+		positionalArgs cobra.PositionalArgs
+		args           []string
+		wantErr        bool
+	}{
+		{
+			name:           "valid args",
+			positionalArgs: cobra.MaximumNArgs(2),
+			args:           []string{"arg1", "arg2"},
+			wantErr:        false,
+		},
+		{
+			name:           "invalid args",
+			positionalArgs: cobra.MaximumNArgs(2),
+			args:           []string{"arg1", "arg2", "arg3"},
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidationWrapper(tt.positionalArgs)(nil, tt.args)
+			if tt.wantErr {
+				var validationError ValidationError
+				require.ErrorAs(t, err, &validationError)
+				require.NotNil(t, validationError.error)
+				require.ErrorContains(t, validationError.error, "accepts at most")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/commands/watch.go
+++ b/internal/commands/watch.go
@@ -45,7 +45,7 @@ func RegisterWatchRelationshipCmd(parentCmd *cobra.Command) *cobra.Command {
 var watchCmd = &cobra.Command{
 	Use:        "watch [object_types, ...] [start_cursor]",
 	Short:      "Watches the stream of relationship updates from the server",
-	Args:       cobra.RangeArgs(0, 2),
+	Args:       ValidationWrapper(cobra.RangeArgs(0, 2)),
 	RunE:       watchCmdFunc,
 	Deprecated: "deprecated; please use `zed watch relationships` instead",
 }
@@ -53,7 +53,7 @@ var watchCmd = &cobra.Command{
 var watchRelationshipsCmd = &cobra.Command{
 	Use:   "watch [object_types, ...] [start_cursor]",
 	Short: "Watches the stream of relationship updates from the server",
-	Args:  cobra.RangeArgs(0, 2),
+	Args:  ValidationWrapper(cobra.RangeArgs(0, 2)),
 	RunE:  watchCmdFunc,
 }
 


### PR DESCRIPTION
Built on top of https://github.com/authzed/zed/pull/492

The usage was being printed on any error, which was rather unpleasant to look at because it made the output difficult to parse for clues on what happened. The primary goal of this commit is to enhance the user experience.

Cobra supports `SilenceErrors` and `SilenceUsage`, as well as a callback function, `SetFlagErrorFunc`, for handling flag parsing errors and controlling when usage and errors are printed. Unfortunately, only a subset of errors fall under the "flag parsing error" category: validation errors defined via `Command.Args` do not trigger `FlagErrorFunc`, so if `SilenceUsage` is enabled, we would miss the usage for those validation cases 😢

To address this, a special error wrapper is introduced that signals an error is a validation error, allowing the command to manually print the usage when `SilenceUsage` is enabled, which this commit does.

A few tests are added that assert the output. Due to the pervasive use of globals, some refactoring was conducted in `cmd.go` to make it more test-friendly.

This is what the command line output looked like when a normal application error happened:
```sh

```shell
$ zed preview schema compile root.zed
Usage:
  zed preview schema compile <file> [flags]

Examples:

        Write to stdout:
                zed preview schema compile root.zed
        Write to an output file:
                zed preview schema compile --out compiled.zed
        

Flags:
  -h, --help         help for compile
      --out string   output filepath; omitting writes to stdout

Global Flags:
      --certificate-path string     path to certificate authority used to verify secure connections
      --endpoint string             spicedb gRPC API endpoint
      --hostname-override string    override the hostname used in the connection to the endpoint
      --insecure                    connect over a plaintext connection
      --log-format string           format of logs ("auto", "console", "json") (default "auto")
      --log-level string            verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
      --max-message-size int        maximum size *in bytes* (defaults to 4_194_304 bytes ~= 4MB) of a gRPC message that can be sent or received by zed
      --no-verify-ca                do not attempt to verify the server's certificate chain and host name
      --permissions-system string   permissions system to query
      --request-id string           optional id to send along with SpiceDB requests for tracing
      --skip-version-check          if true, no version check is performed against the server
      --token string                token used to authenticate to SpiceDB

3:29PM ERR terminated with errors error="failed to read schema file: open root.zed: no such file or directory"
```

This is what it looks like now after the change
```shell

```shell
$ zed preview schema compile root.zed
3:29PM ERR terminated with errors error="failed to read schema file: open root.zed: no such file or directory"
```