### PR TITLE
fix flakey validate test

### DIFF
--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -10,10 +10,10 @@ import (
 	zedtesting "github.com/authzed/zed/internal/testing"
 )
 
-var durationRegex = regexp.MustCompile(`\([\d.]*µs\)`)
+var durationRegex = regexp.MustCompile(`\([\d.]*[µmn]s\)`)
 
 func stripDuration(s string) string {
-	return durationRegex.ReplaceAllString(s, "(Xµs)")
+	return durationRegex.ReplaceAllString(s, "(Xs)")
 }
 
 func TestValidate(t *testing.T) {


### PR DESCRIPTION
😅 flakiness seen in https://github.com/authzed/zed/actions/runs/14629634822/job/41049218633?pr=496

```
   Explanation:
            	            	-  ⨉ document:1 viewer (Xµs)
            	            	-  └── ⨉ document:1 view (Xµs)
            	            	+  ⨉ document:1 viewer (6.196757ms)
            	            	+  └── ⨉ document:1 view (6.058769ms)
```