### PR TITLE
add client-wide retries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1
 	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.5.4
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1
 	github.com/hamba/avro/v2 v2.28.0
 	github.com/jzelinskie/cobrautil/v2 v2.0.0-20240819150235-f7fe73942d0f
 	github.com/jzelinskie/stringz v0.0.3
@@ -140,7 +141,6 @@ require (
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -55,7 +55,7 @@ var (
 		Short: "Create, restore, and inspect permissions system backups",
 		Args:  cobra.MaximumNArgs(1),
 		// Create used to be on the root, so add it here for back-compat.
-		RunE: backupCreateCmdFunc,
+		RunE: withErrorHandling(backupCreateCmdFunc),
 	}
 
 	backupCreateCmd = &cobra.Command{
@@ -116,8 +116,6 @@ func registerBackupCmd(rootCmd *cobra.Command) {
 	backupCmd.AddCommand(backupCreateCmd)
 	registerBackupCreateFlags(backupCreateCmd)
 
-	backupCreateCmd.Flags().Uint32("page-limit", 0, "defines the number of relationships to be read by requested page during backup")
-
 	backupCmd.AddCommand(backupRestoreCmd)
 	registerBackupRestoreFlags(backupRestoreCmd)
 
@@ -160,6 +158,7 @@ func registerBackupRestoreFlags(cmd *cobra.Command) {
 func registerBackupCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().String("prefix-filter", "", "include only schema and relationships with a given prefix")
 	cmd.Flags().Bool("rewrite-legacy", false, "potentially modify the schema to exclude legacy/broken syntax")
+	cmd.Flags().Uint32("page-limit", 0, "defines the number of relationships to be read by requested page during backup")
 }
 
 func createBackupFile(filename string, returnIfExists bool) (*os.File, bool, error) {

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -76,6 +76,7 @@ func InitialiseRootCmd(zl *cobrazerolog.Builder) *cobra.Command {
 	rootCmd.PersistentFlags().String("request-id", "", "optional id to send along with SpiceDB requests for tracing")
 	rootCmd.PersistentFlags().Int("max-message-size", 0, "maximum size *in bytes* (defaults to 4_194_304 bytes ~= 4MB) of a gRPC message that can be sent or received by zed")
 	rootCmd.PersistentFlags().String("proxy", "", "specify a SOCKS5 proxy address")
+	rootCmd.PersistentFlags().Uint("max-retries", 10, "maximum number of sequential retries to attempt when a request fails")
 	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
 
 	versionCmd := &cobra.Command{


### PR DESCRIPTION
Introduces gRPC middleware to do client-side retries by default. The only flag introduced to customize this behaviour is the maximum number of attempts, which defaults to 20.

Retries are enabled for both unary and streaming bot APIs.


https://github.com/user-attachments/assets/f3ba29ba-e995-4ca6-9a85-493e8f94291a

