### PR TITLE
fix typo in goreleaser.windows.yml

### DIFF
--- a/.goreleaser.windows.yml
+++ b/.goreleaser.windows.yml
@@ -21,7 +21,7 @@ archives:
       - "LICENSE"
     format_overrides:
       - goos: "windows"
-        formats: ["zip"]
+        format: "zip"
 
 chocolateys:
   - name: "zed"


### PR DESCRIPTION
Fix failures to release to chocolatey. https://github.com/authzed/zed/actions/runs/14652457878/job/41121211214

```
• running goreleaser v2.3.2-pro (outdated, latest is v2.8.2)
  ⨯ release failed after 0s                  error=failed to load configuration: yaml: unmarshal errors:
  line 24: field formats not found in type config.FormatOverride
```

We use `goreleaser-pro` v2.3.2, the schema is in https://github.com/goreleaser/goreleaser-pro/blob/v2.3.2-pro/pkg/config/config.go.

The same issue exists in https://github.com/authzed/spicedb/actions/runs/14222628747/job/39854249726. If it works here, I will update there too.