### PR TITLE
amend #500 by letting peter-evans/create-pull-request create the commit

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,20 +42,7 @@ jobs:
         run: |
           mkdir -p docs-repo/$(dirname $TARGET_DOCS_FILE)
           cp -v $GENERATED_DOCS_FILE docs-repo/$TARGET_DOCS_FILE
-          cd docs-repo
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git add $TARGET_DOCS_FILE
-          if ! git diff --cached --exit-code; then
-            git commit -m "Update generated docs"
-            echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
-          else
-            echo "No changes detected"
-            echo "CHANGES_DETECTED=false" >> $GITHUB_ENV
-          fi
-      - name: "Create pull request"
-        if: |
-          env.CHANGES_DETECTED == 'true'
+      - name: "Create commit & pull request"
         uses: "peter-evans/create-pull-request@v7"
         with:
           token: "${{ secrets.PAT_TO_PUSH_TO_DOCS }}"


### PR DESCRIPTION
The issue is that the commit author isn't whom we want it to be. See https://github.com/peter-evans/create-pull-request/issues/3940

After this PR is merged, the expected commit author will be github-actions[bot], https://github.com/peter-evans/create-pull-request/blob/450b15d522a9a77a845754ffce4e67c55697bc2c/action.yml#L27, 

which is already a part of https://github.com/authzed/actions/blob/main/cla-check/action.yaml#L26