### PR TITLE
Fix import with schema=false

### DIFF
--- a/internal/cmd/import-test/relations-only-schema.zed
+++ b/internal/cmd/import-test/relations-only-schema.zed
@@ -1,0 +1,6 @@
+definition user {}
+
+definition resource {
+  relation user: user
+  permission view = user
+}

--- a/internal/cmd/import-test/relations-only-validation-file.yaml
+++ b/internal/cmd/import-test/relations-only-validation-file.yaml
@@ -1,0 +1,3 @@
+---
+relationships: >-
+  resource:1#user@user:1

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -1,11 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/gookit/color"
 
 	zedtesting "github.com/authzed/zed/internal/testing"
 )
@@ -14,6 +16,14 @@ var durationRegex = regexp.MustCompile(`\([\d.]*[µmn]s\)`)
 
 func stripDuration(s string) string {
 	return durationRegex.ReplaceAllString(s, "(Xs)")
+}
+
+func TestMain(m *testing.M) {
+	// Disable color output in tests
+	fmt.Println("Disabling color")
+	color.Disable()
+
+	m.Run()
 }
 
 func TestValidatePreRun(t *testing.T) {
@@ -59,6 +69,8 @@ func TestValidatePreRun(t *testing.T) {
 func TestValidate(t *testing.T) {
 	t.Parallel()
 
+	fmt.Println("term color level before tests")
+	fmt.Println(color.TermColorLevel().String())
 	testCases := map[string]struct {
 		schemaTypeFlag          string
 		files                   []string
@@ -293,4 +305,7 @@ complete - 0 relationships loaded, 0 assertions run, 0 expected relations valida
 			require.Equal(tc.expectNonZeroStatusCode, shouldError)
 		})
 	}
+
+	fmt.Println("term color level after tests")
+	fmt.Println(color.TermColorLevel().String())
 }


### PR DESCRIPTION
Fixes #509 

## Description
There's a couple of misbehaviors around `zed import` that we want to fix:

* The command fails if the validation file doesn't have a schema even if schema=false is passed
* The command overwrites the schema if a schema is provided and schema=false is passed

Neither of these is desirable. This PR adds tests for those.

It also fixes an issue with color output breaking tests locally for Linux users.

## Changes
TODO

## Testing
TODO