### PR TITLE
changes to get the tests to pass on Windows

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -25,11 +25,14 @@ jobs:
 
   unit:
     name: "Run Unit Tests"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"] # TODO(miparnisari): add "windows-latest" after fixing the tests
+
     steps:
       - uses: "actions/checkout@v4"
       - uses: "authzed/actions/setup-go@main"
-      - uses: "authzed/action-spicedb@v1"
       - uses: "authzed/actions/go-test@main"
 
   development:

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -26,6 +26,10 @@ func TestGetTokenWithCLIOverride(t *testing.T) {
 	require := require.New(t)
 	testCert, err := os.CreateTemp(t.TempDir(), "")
 	require.NoError(err)
+	t.Cleanup(func() {
+		_ = testCert.Close()
+		_ = os.Remove(testCert.Name())
+	})
 	_, err = testCert.Write([]byte("hi"))
 	require.NoError(err)
 	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,

--- a/internal/cmd/backup_test.go
+++ b/internal/cmd/backup_test.go
@@ -173,10 +173,8 @@ func TestBackupParseRelsCmdFunc(t *testing.T) {
 			backupName := createTestBackup(t, tt.schema, tt.relationships)
 			f, err := os.CreateTemp(t.TempDir(), "parse-output")
 			require.NoError(t, err)
-			defer func() {
-				_ = f.Close()
-			}()
 			t.Cleanup(func() {
+				_ = f.Close()
 				_ = os.Remove(f.Name())
 			})
 
@@ -194,10 +192,8 @@ func TestBackupParseRevisionCmdFunc(t *testing.T) {
 	backupName := createTestBackup(t, testSchema, testRelationships)
 	f, err := os.CreateTemp(t.TempDir(), "parse-output")
 	require.NoError(t, err)
-	defer func() {
-		_ = f.Close()
-	}()
 	t.Cleanup(func() {
+		_ = f.Close()
 		_ = os.Remove(f.Name())
 	})
 
@@ -254,10 +250,8 @@ func TestBackupParseSchemaCmdFunc(t *testing.T) {
 			backupName := createTestBackup(t, tt.schema, nil)
 			f, err := os.CreateTemp(t.TempDir(), "parse-output")
 			require.NoError(t, err)
-			defer func() {
-				_ = f.Close()
-			}()
 			t.Cleanup(func() {
+				_ = f.Close()
 				_ = os.Remove(f.Name())
 			})
 
@@ -328,8 +322,12 @@ func TestBackupCreateCmdFunc(t *testing.T) {
 
 	t.Run("fails if backup without progress file exists", func(t *testing.T) {
 		tempFile := filepath.Join(t.TempDir(), uuid.NewString())
-		_, err := os.Create(tempFile)
+		f, err := os.Create(tempFile)
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+		})
 
 		err = backupCreateCmdFunc(cmd, []string{tempFile})
 		require.ErrorContains(t, err, "already exists")

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -108,6 +108,10 @@ func setupOutputForTest(t *testing.T, testFlagError func(cmd *cobra.Command, err
 	tempStdErrFileName := filepath.Join(t.TempDir(), uuid.NewString())
 	tempStdErr, err := os.Create(tempStdErrFileName)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = tempStdErr.Close()
+		_ = os.Remove(tempStdErrFileName)
+	})
 
 	os.Stderr = tempStdErr
 	return tempStdErrFileName

--- a/internal/cmd/helpers_test.go
+++ b/internal/cmd/helpers_test.go
@@ -40,13 +40,16 @@ func readLines(t *testing.T, fileName string) []string {
 	return lines
 }
 
+// createTestBackup creates a test backup file with the given schema and relationships.
+// It returns the file name of the created backup.
+// When the test is done, the file is closed and removed.
 func createTestBackup(t *testing.T, schema string, relationships []string) string {
 	t.Helper()
 
 	f, err := os.CreateTemp(t.TempDir(), "test-backup")
 	require.NoError(t, err)
-	defer f.Close()
 	t.Cleanup(func() {
+		_ = f.Close()
 		_ = os.Remove(f.Name())
 	})
 

--- a/internal/cmd/restorer_test.go
+++ b/internal/cmd/restorer_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -68,7 +67,6 @@ func TestRestorer(t *testing.T) {
 			require.NoError(err)
 			t.Cleanup(func() {
 				require.NoError(closer.Close())
-				require.NoError(os.Remove(backupFileName))
 			})
 
 			expectedFilteredRels := make([]string, 0, len(tt.relationships))

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,6 +15,10 @@ var durationRegex = regexp.MustCompile(`\([\d.]*[µmn]s\)`)
 
 func stripDuration(s string) string {
 	return durationRegex.ReplaceAllString(s, "(Xs)")
+}
+
+func normalizeNewlines(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }
 
 func TestValidatePreRun(t *testing.T) {
@@ -83,9 +88,9 @@ func TestValidate(t *testing.T) {
 				filepath.Join("validate-test", "standard-validation.yaml"),
 				filepath.Join("validate-test", "external-schema.yaml"),
 			},
-			expectStr: `validate-test/standard-validation.yaml
+			expectStr: filepath.Join("validate-test", "standard-validation.yaml") + `
 Success! - 1 relationships loaded, 2 assertions run, 0 expected relations validated
-validate-test/external-schema.yaml
+` + filepath.Join("validate-test", "external-schema.yaml") + `
 Success! - 1 relationships loaded, 2 assertions run, 0 expected relations validated
 total files: 2, successfully validated files: 2
 `,
@@ -285,7 +290,7 @@ complete - 0 relationships loaded, 0 assertions run, 0 expected relations valida
 			res, shouldError, err := validateCmdFunc(cmd, tc.files)
 			if tc.expectErr == "" {
 				require.NoError(err)
-				require.Equal(stripDuration(tc.expectStr), stripDuration(res))
+				require.Equal(normalizeNewlines(stripDuration(tc.expectStr)), normalizeNewlines(stripDuration(res)))
 			} else {
 				require.Error(err)
 				require.Contains(err.Error(), tc.expectErr)

--- a/internal/decode/decoder.go
+++ b/internal/decode/decoder.go
@@ -124,7 +124,7 @@ func unmarshalAsYAMLOrSchemaWithFile(data []byte, out interface{}, filename stri
 		// NOTE: This does not allow for yaml files to transitively reference
 		// each other's schemaFile fields.
 		// TODO: enable this behavior
-		schemaPath := filepath.Join(path.Dir(filename), validationFile.SchemaFile)
+		schemaPath := filepath.Join(filepath.Dir(filename), validationFile.SchemaFile)
 
 		if !filepath.IsLocal(schemaPath) {
 			// We want to prevent access of files that are outside of the folder


### PR DESCRIPTION
```sh

C:\Users\mparn\Documents\GitHub\zed (main)
λ go test -race ./... -count=1
?       github.com/authzed/zed/cmd/zed  [no test files]
{"level":"trace","context-override-via-cli":true,"context":{"Name":"","Endpoint":"e1","APIToken":"t1","Insecure":true,"NoVerifyCA":true,"CACert":"aGk="},"time":"2025-05-08T14:58:25-07:00"}
{"level":"trace","context-override-via-cli":false,"context":{"Name":"","Endpoint":"e2","APIToken":"t2","Insecure":false,"NoVerifyCA":false,"CACert":"Ynll"},"time":"2025-05-08T14:58:25-07:00"}
--- FAIL: TestGetTokenWithCLIOverride (1.45s)
    testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestGetTokenWithCLIOverride2482217832\001\3569675982: The process cannot access the file because it is being used by another process.
{"level":"trace","context-override-via-cli":true,"context":{"Name":"","Endpoint":"e1","APIToken":"t1","Insecure":true,"NoVerifyCA":false,"CACert":null},"time":"2025-05-08T14:58:26-07:00"}
{"level":"trace","context-override-via-cli":true,"context":{"Name":"","Endpoint":"e1","APIToken":"t1","Insecure":true,"NoVerifyCA":false,"CACert":null},"time":"2025-05-08T14:58:26-07:00"}
{"level":"error","error":"rpc error: code = Unavailable desc = ","attempt":1,"time":"2025-05-08T14:58:27-07:00","message":"retrying gRPC call"}
{"level":"trace","trailers":{"content-type":["application/grpc"]},"time":"2025-05-08T14:58:27-07:00","message":"parsed trailers"}
{"level":"debug","error":"key `io.spicedb.respmeta.dispatchedoperationscount` not found in trailer","time":"2025-05-08T14:58:27-07:00","message":"error reading dispatched operations trailer"}
{"level":"debug","error":"key `io.spicedb.respmeta.cachedoperationscount` not found in trailer","time":"2025-05-08T14:58:27-07:00","message":"error reading cached operations trailer"}
{"level":"debug","dispatch":0,"cached":0,"time":"2025-05-08T14:58:27-07:00","message":"extracted response dispatch metadata"}
FAIL
FAIL    github.com/authzed/zed/internal/client  1.994s
--- FAIL: TestBackupCreateCmdFunc (2.46s)
    --- FAIL: TestBackupCreateCmdFunc/fails_if_backup_without_progress_file_exists (1.62s)
        testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestBackupCreateCmdFuncfails_if_backup_without_progress_file_exists952515208\001\1b5e1504-8293-4c95-989a-8297c1b66451: The process cannot access the file because it is being used by another process.
--- FAIL: TestCommandOutput (7.85s)
    --- FAIL: TestCommandOutput/prints_usage_on_invalid_command_error (1.48s)
        testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestCommandOutputprints_usage_on_invalid_command_error3035192346\001\f737b212-2212-406e-b525-17dfe67a00c9: The process cannot access the file because it is being used by another process.
    --- FAIL: TestCommandOutput/prints_usage_on_invalid_flag_error (1.76s)
        testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestCommandOutputprints_usage_on_invalid_flag_error4215485033\001\b9208287-4881-43cd-8e35-3c2948a7189a: The process cannot access the file because it is being used by another process.
    --- FAIL: TestCommandOutput/prints_usage_on_parameter_validation_error (1.65s)
        testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestCommandOutputprints_usage_on_parameter_validation_error3170615837\001\69334340-df0c-4ee4-b22d-4437409ef1f0: The process cannot access the file because it is being used by another process.
    --- FAIL: TestCommandOutput/prints_correct_usage (1.47s)
        testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestCommandOutputprints_correct_usage3136258689\001\03e53205-9fb0-4884-9162-d1169832df02: The process cannot access the file because it is being used by another process.
    --- FAIL: TestCommandOutput/does_not_print_usage_on_command_error (1.49s)
        testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestCommandOutputdoes_not_print_usage_on_command_error900788158\001\9019e5c4-9c83-4328-8458-6d9e3134e937: The process cannot access the file because it is being used by another process.
--- FAIL: TestImportCmdHappyPath (0.01s)
    import_test.go:49:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/import_test.go:49
                Error:          Received unexpected error:
                                open happy-path-validation-schema.zed: The system cannot find the file specified.
                Test:           TestImportCmdHappyPath
--- FAIL: TestSchemaCompile (0.00s)
    --- FAIL: TestSchemaCompile/file_not_found (0.00s)
        schema_test.go:174:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/schema_test.go:174
                Error:          "failed to read schema file: open preview-test\\nonexistent.zed: The system cannot find the file specified." does not contain "no such file or directory"
                Test:           TestSchemaCompile/file_not_found
--- FAIL: TestValidate (0.00s)
    --- FAIL: TestValidate/external_schema_passes (0.00s)
        validate_test.go:287:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/validate_test.go:287
                Error:          Received unexpected error:
                                open external-schema.zed: The system cannot find the file specified.
                Test:           TestValidate/external_schema_passes
    --- FAIL: TestValidate/composable_in_validation_yaml_with_standard_fails (0.00s)
        validate_test.go:291:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/validate_test.go:291
                Error:          "open composable-schema-root.zed: The system cannot find the file specified." does not contain "Unexpected token at root level"
                Test:           TestValidate/composable_in_validation_yaml_with_standard_fails
    --- FAIL: TestValidate/assertions_fail (0.01s)
        validate_test.go:288:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/validate_test.go:288
                Error:          Not equal:
                                expected: "error:  Expected relation or permission document:1#viewer@user:maria to exist           \n  8 |   }\n  9 | assertions:\n 10 |   assertTrue:\n 11 >     - \"document:1#viewer@user:maria\"\n    >
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~\n 12 | \n\n  Explanation:\n  ⨉ document:1 viewer (Xs)\n  └── ⨉ document:1 view (Xs)\n  \n\n\n"
                                actual  : "error:  Expected relation or permission document:1#viewer@user:maria to exist           \n  8 |   }\n  9 | assertions:\n 10 |   assertTrue:\n 11 >     - \"document:1#viewer@user:maria\"\n    >
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~\n 12 | \n\n  Explanation:\n  \x1b[31m⨉\x1b[0m \x1b[90mdocument\x1b[0m:\x1b[90m1\x1b[0m \x1b[90mviewer\x1b[0m (Xs)\n  └── \x1b[31m⨉\x1b[0m \x1b[90mdocument\x1b[0m:\x1b[90m1\x1b[0m \x1b[90mview\x1b[0m (Xs)\n  \n\n\n"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -9,4 +9,4 @@
                                   Explanation:
                                -  ⨉ document:1 viewer (Xs)
                                -  └── ⨉ document:1 view (Xs)
                                +  ⨉ document:1 viewer (Xs)
                                +  └── ⨉ document:1 view (Xs)

                Test:           TestValidate/assertions_fail
    --- FAIL: TestValidate/composable_in_validation_yaml_with_composable_passes (0.00s)
        validate_test.go:287:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/validate_test.go:287
                Error:          Received unexpected error:
                                open composable-schema-root.zed: The system cannot find the file specified.
                Test:           TestValidate/composable_in_validation_yaml_with_composable_passes
    --- FAIL: TestValidate/multiple_files_passes (0.01s)
        validate_test.go:287:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/validate_test.go:287
                Error:          Received unexpected error:
                                open external-schema.zed: The system cannot find the file specified.
                Test:           TestValidate/multiple_files_passes
FAIL
FAIL    github.com/authzed/zed/internal/cmd     14.450s
--- FAIL: TestWriteRelationshipsArgs (1.75s)
    testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestWriteRelationshipsArgs3195926403\001\spicedb-3668298210: The process cannot access the file because it is being used by another process.
{
  "writtenAt": {
    "token": "test"
  }
}
--- FAIL: TestWriteRelationshipCmdFuncFromTTY (1.88s)
    testing.go:1267: TempDir RemoveAll cleanup: remove C:\Users\mparn\AppData\Local\Temp\TestWriteRelationshipCmdFuncFromTTY4215383988\001\spicedb-1802411991: The process cannot access the file because it is being used by another process.

{
  "writtenAt": {
    "token": "test"
  }
}
{
  "writtenAt": {
    "token": "test"
  }
}
{
  "writtenAt": {
    "token": "test"
  }
}
{
  "writtenAt": {
    "token": "test"
  }
}
{
  "writtenAt": {
    "token": "test"
  }
}
{
  "writtenAt": {
    "token": "test"
  }
}
{
  "writtenAt": {
    "token": "test"
  }
}
{
  "writtenAt": {
    "token": "test"
  }
}
GhUKEzE3NDY3NDE1MTIxMDc1OTU1MDE=
GhUKEzE3NDY3NDE1MTI1NDYxNjk4MDA=
--- FAIL: TestBulkDeleteManyForcing (0.45s)
    relationship_test.go:761:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/commands/relationship_test.go:844
                                                        C:/Users/mparn/Documents/GitHub/zed/internal/commands/relationship_test.go:816
                                                        C:/Users/mparn/Documents/GitHub/zed/internal/commands/relationship_test.go:761
                Error:          Not equal:
                                expected: 0
                                actual  : 3
                Test:           TestBulkDeleteManyForcing
FAIL
FAIL    github.com/authzed/zed/internal/commands        5.132s
?       github.com/authzed/zed/internal/console [no test files]
ok      github.com/authzed/zed/internal/decode  1.242s
ok      github.com/authzed/zed/internal/grpcutil        2.273s
ok      github.com/authzed/zed/internal/printers        1.242s
ok      github.com/authzed/zed/internal/storage 1.525s
?       github.com/authzed/zed/internal/testing [no test files]
?       github.com/authzed/zed/magefiles        [no test files]
ok      github.com/authzed/zed/pkg/backupformat 1.687s
FAIL

C:\Users\mparn\Documents\GitHub\zed (main)
```