### PR TITLE
Update go.mod to retract v1.14.0 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.24
 
 toolchain go1.24.1
 
+// 0.14.0 was published as 1.14.0 by mistake
+retract v1.14.0
+
 require (
 	github.com/99designs/keyring v1.2.2
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2


### PR DESCRIPTION
See https://pkg.go.dev/github.com/authzed/zed?tab=versions
+ https://go.dev/blog/go116-module-changes#TOC_5.