### PR TITLE
added a verbose message for keyring error

### DIFF
--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -147,7 +147,7 @@ var _ SecretStore = (*KeychainSecretStore)(nil)
 const (
 	svcName                   = "zed"
 	keyringEntryName          = svcName + " secrets"
-	envRecommendation         = "Setting the environment variable `ZED_KEYRING_PASSWORD` to your password will skip prompts.\n"
+	envRecommendation         = "If your platform doesn't have a native keychain manager (e.g. macOS, Linux+GNOME/KDE), ZED_KEYRING_PASSWORD is what's used to encrypt files on disk to store credentials. The first time you create a context, it'll prompt you to create a keyring password to encrypt that configuration. \n"
 	keyringDoesNotExistPrompt = "Keyring file does not already exist.\nEnter a new non-empty passphrase for the new keyring file: "
 	keyringPrompt             = "Enter passphrase to unlock zed keyring: "
 	emptyKeyringPasswordError = "your passphrase must not be empty"


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

When a system doesn't have a native keyring manager, this is what the current error message is:

```
Setting the environment variable `ZED_KEYRING_PASSWORD` to your password will skip prompts.
Keyring file does not already exist.
Enter a new non-empty passphrase for the new keyring file: 
```

This doesn't explain why this error is popping up, so i've added a line for more details about it. The new message will read:

```
If your platform doesn't have a native keychain manager (e.g. macOS, Linux+GNOME/KDE), ZED_KEYRING_PASSWORD is what's used to encrypt files on disk to store credentials. The first time you create a context, it'll prompt you to create a keyring password to encrypt that configuration.
Keyring file does not already exist.
Enter a new non-empty passphrase for the new keyring file: 
```

It's a bit more verbose, but provides more context. 

## Testing

Tried `zed context` on the Instruqt platform VM which didn't have a native keyring manger and saw this message. 

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->