### PR TITLE
fix(permission): LookupResource should stop the stream according to --page-limit argument

### DIFF
--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -504,6 +504,9 @@ func lookupResourcesCmdFunc(cmd *cobra.Command, args []string) error {
 			default:
 				count++
 				totalCount++
+				if pageLimit > 0 && totalCount > uint(pageLimit) {
+					break stream
+				}
 				if cobrautil.MustGetBool(cmd, "json") {
 					prettyProto, err := PrettyProto(resp)
 					if err != nil {


### PR DESCRIPTION
`zed` calls the LookupResource in a loop, and automatically provides the cursor token. This causes the `--page-limit` to have practically no effect from user's perspective.