### PR TITLE
Add fail-on-warn flag to validate

### DIFF
--- a/internal/cmd/validate-test/schema-with-warnings.zed
+++ b/internal/cmd/validate-test/schema-with-warnings.zed
@@ -1,0 +1,10 @@
+definition user {}
+
+definition resource {
+  relation user: user
+
+  // NOTE: This is what will throw the warning -
+  // we recommend that you don't put the resource name
+  // in the permission.
+  permission view_resource = user
+}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -49,6 +49,7 @@ var (
 
 func registerValidateCmd(cmd *cobra.Command) {
 	validateCmd.Flags().Bool("force-color", false, "force color code output even in non-tty environments")
+	validateCmd.Flags().Bool("fail-on-warn", false, "treat warnings as errors during validation")
 	validateCmd.Flags().String("schema-type", "", "force validation according to specific schema syntax (\"\", \"composable\", \"standard\")")
 	cmd.AddCommand(validateCmd)
 }
@@ -129,6 +130,7 @@ func validateCmdFunc(cmd *cobra.Command, filenames []string) (string, bool, erro
 		shouldExit                 = false
 		toPrint                    = &strings.Builder{}
 		schemaType                 = cobrautil.MustGetString(cmd, "schema-type")
+		failOnWarn                 = cobrautil.MustGetBool(cmd, "fail-on-warn")
 	)
 
 	for _, filename := range filenames {
@@ -249,6 +251,9 @@ func validateCmdFunc(cmd *cobra.Command, filenames []string) (string, bool, erro
 			}
 
 			toPrint.WriteString(complete())
+			// If we have warnings, we use the failOnWarn flag's value
+			// to decide whether to exit with an error.
+			shouldExit = failOnWarn
 		} else {
 			toPrint.WriteString(success())
 		}


### PR DESCRIPTION
Fixes #536 
## Description
This is to provide stricter validation for the folks that want it. This adds a `fail-on-warn` flag that treats warnings as errors, e.g. for CI. This brings zed closer to inline with other linters.

## Change
* Add a test for `fail-on-warn`
* Add a `fail-on-warn` flag

## Testing
Review. See that tests pass. Give me :bike: :house: feedback about the name of the flag.