### PR TITLE
Fix backup retry behavior

### DIFF
--- a/internal/cmd/backup_test.go
+++ b/internal/cmd/backup_test.go
@@ -438,6 +438,8 @@ func TestBackupCreateCmdFunc(t *testing.T) {
 		}
 		validateBackupWithFunc(t, f, testSchema, resp.WrittenAt, expectedRels, validationFunc)
 	})
+	t.Run("retryable errors pick up where the stream left off", func(_ *testing.T) {
+	})
 }
 
 type testConfigStore struct {


### PR DESCRIPTION
Fixes #542 

## Description
Currently, `ExportBulk` is on the list of retryable methods. That means that when an export stream errors for any reason, the request is re-issued. This is a problem because it starts at the beginning and the relations are appended naively to the output. Ideally we'd resume from the place where the error occurred, and that's what this PR implements.

## Changes
* Add `ExportBulk` to the list of things that doesn't get retried
* Add manual retryable error handling that overwrites the existing stream
## Testing
Review. See that tests pass.