### PR TITLE
Disable first-line-heading markdownlint rule

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,3 +1,4 @@
 ---
 line-length: false
 no-hard-tabs: false
+MD041: false

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable-next-line MD041 -->
 import { Callout } from 'nextra/components'
 
 # Installing Zed


### PR DESCRIPTION
Disabling the first line heading lint rule to accommodate import statements in destination mdx files.

Docs .md files in this repo are processed and used in mdx files in the docs repo. However, mdx files do not
allow html comments so individual line exemptions for markdownlint do not work.
