### PR TITLE
test: fix flaky TestValidate

### DIFF
--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-var durationRegex = regexp.MustCompile(`\([\d.]*[µmn]s\)`)
+var durationRegex = regexp.MustCompile(`\([\d.]*[µmn]?s\)`)
 
 func stripDuration(s string) string {
 	return durationRegex.ReplaceAllString(s, "(Xs)")


### PR DESCRIPTION
Fixes a flaky test on my Windows machine that apparently is too slow 😆 

```go
C:\Users\mparn\Documents\GitHub\zed (main -> origin)
λ go test -race -count=1 ./...
?       github.com/authzed/zed/cmd/zed  [no test files]
ok      github.com/authzed/zed/internal/client  1.623s
--- FAIL: TestValidate (0.00s)
    --- FAIL: TestValidate/assertions_fail (0.01s)
        validate_test.go:329:
                Error Trace:    C:/Users/mparn/Documents/GitHub/zed/internal/cmd/validate_test.go:329
                Error:          Not equal:
                                expected: "error: parse error in `document:1#viewer@user:maria`, line 11, column 7: Expected relation or permission document:1#viewer@user:maria to exist           \n  8 |   }\n  9 | assertions:\n 10 |   assertTrue:\n 11 >     - \"document:1#viewer@user:maria\"\n    >        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~\n 12 | \n\n  Explanation:\n  ⨉ document:1 viewer (Xs)\n  └── ⨉ document:1 view (Xs)\n  \n\n\n"
                                actual  : "error: parse error in `document:1#viewer@user:maria`, line 11, column 7: Expected relation or permission document:1#viewer@user:maria to exist           \n  8 |   }\n  9 | assertions:\n 10 |   assertTrue:\n 11 >     - \"document:1#viewer@user:maria\"\n    >        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~\n 12 | \n\n  Explanation:\n  ⨉ document:1 viewer (0s)\n  └── ⨉ document:1 view (0s)\n  \n\n\n"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -9,4 +9,4 @@
                                   Explanation:
                                -  ⨉ document:1 viewer (Xs)
                                -  └── ⨉ document:1 view (Xs)
                                +  ⨉ document:1 viewer (0s)
                                +  └── ⨉ document:1 view (0s)

                Test:           TestValidate/assertions_fail
FAIL
FAIL    github.com/authzed/zed/internal/cmd     4.650s
```