### PR TITLE
breaking: Clean up deprecated functionality for v1

### DIFF
--- a/docs/zed.md
+++ b/docs/zed.md
@@ -650,7 +650,6 @@ zed permission bulk <resource:id#permission@subject:id> <resource:id#permission@
       --consistency-min-latency         evaluate at the zedtoken preferred by the database
       --explain                         requests debug information from SpiceDB and prints out a trace of the requests
       --json                            output as JSON
-      --revision string                 optional revision at which to check
       --schema                          requests debug information from SpiceDB and prints out the schema used
 ```
 
@@ -734,7 +733,6 @@ zed permission expand <permission> <resource:id> [flags]
       --consistency-full                evaluate at the newest zedtoken in the database
       --consistency-min-latency         evaluate at the zedtoken preferred by the database
       --json                            output as JSON
-      --revision string                 optional revision at which to check
 ```
 
 ### Options Inherited From Parent Flags
@@ -777,7 +775,6 @@ zed permission lookup-resources <type> <permission> <subject:id> [flags]
       --cursor string                   resume pagination from a specific cursor token
       --json                            output as JSON
       --page-limit uint32               limit of relations returned per page
-      --revision string                 optional revision at which to check
       --show-cursor                     display the cursor token after pagination (default true)
 ```
 
@@ -819,55 +816,6 @@ zed permission lookup-subjects <resource:id> <permission> <subject_type#optional
       --consistency-full                evaluate at the newest zedtoken in the database
       --consistency-min-latency         evaluate at the zedtoken preferred by the database
       --json                            output as JSON
-      --revision string                 optional revision at which to check
-```
-
-### Options Inherited From Parent Flags
-
-```
-      --certificate-path string     path to certificate authority used to verify secure connections
-      --endpoint string             spicedb gRPC API endpoint
-      --hostname-override string    override the hostname used in the connection to the endpoint
-      --insecure                    connect over a plaintext connection
-      --log-format string           format of logs ("auto", "console", "json") (default "auto")
-      --log-level string            verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
-      --max-message-size int        maximum size *in bytes* (defaults to 4_194_304 bytes ~= 4MB) of a gRPC message that can be sent or received by zed
-      --max-retries uint            maximum number of sequential retries to attempt when a request fails (default 10)
-      --no-verify-ca                do not attempt to verify the server's certificate chain and host name
-      --permissions-system string   permissions system to query
-      --proxy string                specify a SOCKS5 proxy address
-      --request-id string           optional id to send along with SpiceDB requests for tracing
-      --skip-version-check          if true, no version check is performed against the server
-      --token string                token used to authenticate to SpiceDB
-```
-
-
-
-## Reference: `zed preview schema compile`
-
-Compile a schema that uses import syntax into one that can be written to SpiceDB
-
-```
-zed preview schema compile <file> [flags]
-```
-
-### Examples
-
-```
-
-	Write to stdout:
-		zed schema compile root.zed
-	Write to redirected stdout:
-		zed schema compile schema.zed 1> compiled.zed
-	Write to a file:
-		zed schema compile root.zed --out compiled.zed
-	
-```
-
-### Options
-
-```
-      --out string   output filepath; omitting writes to stdout
 ```
 
 ### Options Inherited From Parent Flags
@@ -1219,6 +1167,54 @@ Manage schema for a permissions system
 - [zed schema diff](#reference-zed-schema-diff)	 - Diff two schema files
 - [zed schema read](#reference-zed-schema-read)	 - Read the schema of a permissions system
 - [zed schema write](#reference-zed-schema-write)	 - Write a schema file (.zed or stdin) to the current permissions system
+
+
+## Reference: `zed schema compile`
+
+Compile a schema that uses import syntax into one that can be written to SpiceDB
+
+```
+zed schema compile <file> [flags]
+```
+
+### Examples
+
+```
+
+	Write to stdout:
+		zed schema compile root.zed
+	Write to redirected stdout:
+		zed schema compile schema.zed 1> compiled.zed
+	Write to a file:
+		zed schema compile root.zed --out compiled.zed
+	
+```
+
+### Options
+
+```
+      --out string   output filepath; omitting writes to stdout
+```
+
+### Options Inherited From Parent Flags
+
+```
+      --certificate-path string     path to certificate authority used to verify secure connections
+      --endpoint string             spicedb gRPC API endpoint
+      --hostname-override string    override the hostname used in the connection to the endpoint
+      --insecure                    connect over a plaintext connection
+      --log-format string           format of logs ("auto", "console", "json") (default "auto")
+      --log-level string            verbosity of logging ("trace", "debug", "info", "warn", "error") (default "info")
+      --max-message-size int        maximum size *in bytes* (defaults to 4_194_304 bytes ~= 4MB) of a gRPC message that can be sent or received by zed
+      --max-retries uint            maximum number of sequential retries to attempt when a request fails (default 10)
+      --no-verify-ca                do not attempt to verify the server's certificate chain and host name
+      --permissions-system string   permissions system to query
+      --proxy string                specify a SOCKS5 proxy address
+      --request-id string           optional id to send along with SpiceDB requests for tracing
+      --skip-version-check          if true, no version check is performed against the server
+      --token string                token used to authenticate to SpiceDB
+```
+
 
 
 ## Reference: `zed schema copy`

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -123,12 +123,11 @@ zed permission check --explain document:firstdoc writer user:emilia
 
 	relCmd := commands.RegisterRelationshipCmd(rootCmd)
 
-	commands.RegisterWatchCmd(rootCmd)
 	commands.RegisterWatchRelationshipCmd(relCmd)
 
 	schemaCmd := commands.RegisterSchemaCmd(rootCmd)
-	schemaCompileCmd := registerAdditionalSchemaCmds(schemaCmd)
-	registerPreviewCmd(rootCmd, schemaCompileCmd)
+	registerAdditionalSchemaCmds(schemaCmd)
+	registerPreviewCmd(rootCmd)
 
 	return rootCmd
 }

--- a/internal/cmd/preview.go
+++ b/internal/cmd/preview.go
@@ -4,19 +4,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func registerPreviewCmd(rootCmd *cobra.Command, schemaCompileCmd *cobra.Command) {
+func registerPreviewCmd(rootCmd *cobra.Command) {
 	previewCmd := &cobra.Command{
 		Use:   "preview <subcommand>",
 		Short: "Experimental commands that have been made available for preview",
 	}
 
-	schemaCmd := &cobra.Command{
-		Use:        "schema <subcommand>",
-		Short:      "Manage schema for a permissions system",
-		Deprecated: "please use `zed schema compile`",
-	}
-
 	rootCmd.AddCommand(previewCmd)
-	previewCmd.AddCommand(schemaCmd)
-	schemaCmd.AddCommand(schemaCompileCmd)
 }

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -38,7 +38,7 @@ func (rtc *realTermChecker) IsTerminal(fd int) bool {
 	return term.IsTerminal(fd)
 }
 
-func registerAdditionalSchemaCmds(schemaCmd *cobra.Command) *cobra.Command {
+func registerAdditionalSchemaCmds(schemaCmd *cobra.Command) {
 	schemaWriteCmd := &cobra.Command{
 		Use:               "write <file?>",
 		Args:              commands.ValidationWrapper(cobra.MaximumNArgs(1)),
@@ -105,8 +105,6 @@ func registerAdditionalSchemaCmds(schemaCmd *cobra.Command) *cobra.Command {
 
 	schemaCmd.AddCommand(schemaCompileCmd)
 	schemaCompileCmd.Flags().String("out", "", "output filepath; omitting writes to stdout")
-
-	return schemaCompileCmd
 }
 
 func schemaDiffCmdFunc(_ *cobra.Command, args []string) error {

--- a/internal/commands/permission_test.go
+++ b/internal/commands/permission_test.go
@@ -66,8 +66,6 @@ func TestCheckErrorWithDebugInformation(t *testing.T) {
 	}()
 
 	cmd := &cobra.Command{}
-	cmd.Flags().String("revision", "", "optional revision at which to check")
-	_ = cmd.Flags().MarkHidden("revision")
 	cmd.Flags().Bool("explain", false, "requests debug information from SpiceDB and prints out a trace of the requests")
 	cmd.Flags().Bool("schema", false, "requests debug information from SpiceDB and prints out the schema used")
 	cmd.Flags().Bool("error-on-no-permission", false, "if true, zed will return exit code 1 if subject does not have unconditional permission")
@@ -91,8 +89,6 @@ func TestCheckErrorWithInvalidDebugInformation(t *testing.T) {
 	}()
 
 	cmd := &cobra.Command{}
-	cmd.Flags().String("revision", "", "optional revision at which to check")
-	_ = cmd.Flags().MarkHidden("revision")
 	cmd.Flags().Bool("explain", false, "requests debug information from SpiceDB and prints out a trace of the requests")
 	cmd.Flags().Bool("schema", false, "requests debug information from SpiceDB and prints out the schema used")
 	cmd.Flags().Bool("error-on-no-permission", false, "if true, zed will return exit code 1 if subject does not have unconditional permission")

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -38,6 +38,7 @@ func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {
 		Args:              ValidationWrapper(StdinOrExactArgs(3)),
 		ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
 		RunE:              writeRelationshipCmdFunc(v1.RelationshipUpdate_OPERATION_CREATE, os.Stdin),
+		Aliases:           []string{"write"},
 		Example: `
   zed relationship create document:budget view user:anne --expiration-time "2025-12-31T23:59:59Z"
   zed relationship create document:budget view user:anne --caveat ip_address:'{"ip": "192.168.0.1"}
@@ -104,8 +105,6 @@ func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {
 
 	relationshipCmd.AddCommand(readCmd)
 	readCmd.Flags().Bool("json", false, "output as JSON")
-	readCmd.Flags().String("revision", "", "optional revision at which to check")
-	_ = readCmd.Flags().MarkHidden("revision")
 	readCmd.Flags().String("subject-filter", "", "optional subject filter")
 	readCmd.Flags().Uint32("page-limit", 100, "limit of relations returned per page")
 	registerConsistencyFlags(readCmd.Flags())
@@ -114,8 +113,6 @@ func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {
 	bulkDeleteCmd.Flags().Bool("force", false, "force deletion of all elements in batches defined by <optional-limit>")
 	bulkDeleteCmd.Flags().String("subject-filter", "", "optional subject filter")
 	bulkDeleteCmd.Flags().Uint32("optional-limit", 1000, "the max amount of elements to delete. If you want to delete all in batches of size <optional-limit>, set --force to true")
-	bulkDeleteCmd.Flags().Bool("estimate-count", true, "estimate the count of relationships to be deleted")
-	_ = bulkDeleteCmd.Flags().MarkDeprecated("estimate-count", "no longer used, make use of --optional-limit instead")
 	return relationshipCmd
 }
 

--- a/internal/commands/watch.go
+++ b/internal/commands/watch.go
@@ -27,22 +27,6 @@ var (
 	watchRelationshipFilters []string
 )
 
-func RegisterWatchCmd(rootCmd *cobra.Command) *cobra.Command {
-	watchCmd := &cobra.Command{
-		Use:        "watch [object_types, ...] [revision]",
-		Short:      "Watches the stream of relationship updates and schema updates from the server",
-		Args:       ValidationWrapper(cobra.RangeArgs(0, 2)),
-		RunE:       watchCmdFunc,
-		Deprecated: "please use `zed relationship watch` instead",
-	}
-
-	rootCmd.AddCommand(watchCmd)
-	watchCmd.Flags().StringSliceVar(&watchObjectTypes, "object_types", nil, "optional object types to watch updates for")
-	watchCmd.Flags().StringVar(&watchRevision, "revision", "", "optional revision at which to start watching")
-	watchCmd.Flags().BoolVar(&watchTimestamps, "timestamp", false, "shows timestamp of incoming update events")
-	return watchCmd
-}
-
 func RegisterWatchRelationshipCmd(parentCmd *cobra.Command) *cobra.Command {
 	watchRelationshipsCmd := &cobra.Command{
 		Use:   "watch [object_types, ...] [revision]",


### PR DESCRIPTION
## Description
Part of getting a v1 of Zed out the door. We want to take the opportunity to get rid of some deprecated codepaths, which will keep complexity down in the long term.

## Changes
* Remove `zed preview schema compile` - it's now just `zed schema compile`
* Remove `zed watch` - it's now just `zed relationship watch`
* Remove deprecated `revision` flag - use the other consistency flags
* Remove `zed permission lookup` - it's `zed permission lookup-resources`
* Remove deprecated `estimated-count` flag on `bulk-delete` - use `limit` instead

## Testing
Review. See that tests still pass.