### PR TITLE
chore: minor fixes to docs

### DIFF
--- a/docs/zed.md
+++ b/docs/zed.md
@@ -539,8 +539,7 @@ MCP (Model Context Protocol) server commands.
 	
 The MCP server provides tooling and resources for developing and debugging SpiceDB schema and relationships. The server runs an in-memory development instance of SpiceDB and does not connect to a running instance of SpiceDB.
 
-To use with Claude Code, run "zed mcp experimental-run" to start the SpiceDB Dev MCP server and then run "claude mcp add --transport http spicedb http://localhost:9999/mcp" to add the server to your Claude Code integrations.
-
+To use with Claude Code, run `zed mcp experimental-run` to start the SpiceDB Dev MCP server and then run `claude mcp add --transport http spicedb "http://localhost:9999/mcp"` to add the server to your Claude Code integrations.
 
 ### Options Inherited From Parent Flags
 
@@ -1293,6 +1292,17 @@ Write a schema file (.zed or stdin) to the current permissions system
 
 ```
 zed schema write <file?> [flags]
+```
+
+### Examples
+
+```
+
+	Write from a file:
+		zed schema write schema.zed
+	Write from stdin:
+		cat schema.zed | zed schema write
+
 ```
 
 ### Options

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -21,8 +21,7 @@ var mcpCmd = &cobra.Command{
 	
 The MCP server provides tooling and resources for developing and debugging SpiceDB schema and relationships. The server runs an in-memory development instance of SpiceDB and does not connect to a running instance of SpiceDB.
 
-To use with Claude Code, run "zed mcp experimental-run" to start the SpiceDB Dev MCP server and then run "claude mcp add --transport http spicedb http://localhost:9999/mcp" to add the server to your Claude Code integrations.
-`,
+To use with Claude Code, run ` + "`zed mcp experimental-run`" + ` to start the SpiceDB Dev MCP server and then run ` + "`claude mcp add --transport http spicedb \"http://localhost:9999/mcp\"`" + ` to add the server to your Claude Code integrations.`,
 }
 
 var mcpRunCmd = &cobra.Command{

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -128,7 +128,7 @@ var permissionCmd = &cobra.Command{
 
 var checkBulkCmd = &cobra.Command{
 	Use:   "bulk <resource:id#permission@subject:id> <resource:id#permission@subject:id> ...",
-	Short: "Check a permissions in bulk exists for a resource-subject pairs",
+	Short: "Check permissions in bulk exist for resource-subject pairs",
 	Args:  ValidationWrapper(cobra.MinimumNArgs(1)),
 	RunE:  checkBulkCmdFunc,
 }
@@ -151,7 +151,7 @@ var expandCmd = &cobra.Command{
 
 var lookupResourcesCmd = &cobra.Command{
 	Use:               "lookup-resources <type> <permission> <subject:id>",
-	Short:             "Enumerates resources of a given type for which the subject has permission",
+	Short:             "Enumerates the resources of a given type for which the subject has permission",
 	Args:              ValidationWrapper(cobra.ExactArgs(3)),
 	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
 	RunE:              lookupResourcesCmdFunc,


### PR DESCRIPTION
Addresses the issues reported in https://github.com/authzed/docs/actions/runs/18353626386/job/52279870193?pr=389#step:9:12

```
markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)
Finding: pages/**/*{.mdx,.md.markdown}
Linting: 68 file(s)
Summary: 2 error(s)
pages/spicedb/getting-started/installing-zed.mdx:665:1 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
pages/spicedb/getting-started/installing-zed.mdx:668:147 MD034/no-bare-urls Bare URL used [Context: "http://localhost:9999/mcp"]
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```