### PR TITLE
fix: suppress retry logs in version command when SpiceDB unavailable

### DIFF
--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -1,16 +1,22 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	"github.com/authzed/authzed-go/pkg/responsemeta"
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 
+	"github.com/authzed/zed/internal/client"
 	zedtesting "github.com/authzed/zed/internal/testing"
 )
 
@@ -137,4 +143,81 @@ func (m *mockSchemaServiceClient) ReadSchema(_ context.Context, _ *v1.ReadSchema
 
 func (m *mockSchemaServiceClient) WriteSchema(_ context.Context, _ *v1.WriteSchemaRequest, _ ...grpc.CallOption) (*v1.WriteSchemaResponse, error) {
 	return nil, nil
+}
+
+func TestVersionCommandWithUnavailableServer(t *testing.T) {
+	// Note: Not running in parallel because we modify globals (client.NewClient, os.Stdout, os.Stderr)
+
+	// This test verifies issue #554 is fixed: when SpiceDB is unavailable,
+	// zed version should not produce noisy retry error logs
+
+	// Save and restore original client.NewClient
+	originalNewClient := client.NewClient
+	t.Cleanup(func() {
+		client.NewClient = originalNewClient
+	})
+
+	// Mock client.NewClient to return Unavailable error
+	client.NewClient = func(_ *cobra.Command) (client.Client, error) {
+		return nil, status.Error(codes.Unavailable, "connection refused")
+	}
+
+	// Capture stdout to check output
+	oldStdout := os.Stdout
+	rOut, wOut, _ := os.Pipe()
+	os.Stdout = wOut
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+	})
+
+	// Capture stderr to verify no retry errors are logged
+	oldStderr := os.Stderr
+	rErr, wErr, _ := os.Pipe()
+	os.Stderr = wErr
+	t.Cleanup(func() {
+		os.Stderr = oldStderr
+	})
+
+	// Create command with all required flags
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+		zedtesting.BoolFlag{FlagName: "include-remote-version", FlagValue: true},
+		zedtesting.BoolFlag{FlagName: "include-deps", FlagValue: false},
+		zedtesting.UintFlag{FlagName: "max-retries", FlagValue: 10},
+		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: ""},
+		zedtesting.StringFlag{FlagName: "token", FlagValue: ""},
+		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: ""},
+		zedtesting.StringFlag{FlagName: "hostname-override", FlagValue: ""},
+		zedtesting.StringFlag{FlagName: "permissions-system", FlagValue: ""},
+		zedtesting.StringFlag{FlagName: "proxy", FlagValue: ""},
+		zedtesting.StringFlag{FlagName: "request-id", FlagValue: ""},
+		zedtesting.BoolFlag{FlagName: "insecure", FlagValue: false},
+		zedtesting.BoolFlag{FlagName: "no-verify-ca", FlagValue: false},
+		zedtesting.BoolFlag{FlagName: "skip-version-check", FlagValue: false},
+		zedtesting.IntFlag{FlagName: "max-message-size", FlagValue: 0},
+	)
+
+	// Run the version command
+	err := versionCmdFunc(cmd, nil)
+
+	// Close writers and read captured outputs
+	wOut.Close()
+	wErr.Close()
+	var stdout bytes.Buffer
+	_, _ = stdout.ReadFrom(rOut)
+	var stderr bytes.Buffer
+	_, _ = stderr.ReadFrom(rErr)
+
+	// Command should succeed despite unavailable server
+	require.NoError(t, err)
+
+	// Stdout should contain client version and service: (unknown)
+	output := stdout.String()
+	require.Contains(t, output, "zed")
+	require.Contains(t, output, "service:")
+	require.Contains(t, output, "(unknown)")
+
+	// Stderr should be empty (no retry error logs)
+	stderrOutput := stderr.String()
+	require.NotContains(t, stderrOutput, "retrying gRPC call")
+	require.NotContains(t, stderrOutput, "Unavailable")
 }


### PR DESCRIPTION
## Summary
Fixes #554 

When running `zed version` with an unavailable SpiceDB instance, the command would retry multiple times and log noisy error messages that cluttered the output.

## Changes
- Disables retries by default for the `version` command (sets `max-retries=0`)
- Respects user-specified `--max-retries` if explicitly set
- Restores both flag value and `Changed` state to preserve flag semantics
- Logs connection failures at debug level instead of error
- Always prints `service: (unknown)` for consistent output format
- Adds test coverage for unavailable server scenario

## Before
```
$ zed version --endpoint=localhost:12345 --insecure
client: zed v0.33.0
{"level":"error","error":"rpc error: code = Unavailable...","attempt":1,...}
{"level":"error","error":"rpc error: code = Unavailable...","attempt":2,...}
{"level":"error","error":"rpc error: code = Unavailable...","attempt":3,...}
... (9+ retry logs)
service: (unknown)
```

## After
```
$ zed version --endpoint=localhost:12345 --insecure
client: zed v0.33.0
service: (unknown)
```

## Test Plan
- All existing tests pass
- Added `TestVersionCommandWithUnavailableServer` to verify silent fallback
- Manually tested with unavailable endpoint (no retry logs)
- Verified user-specified `--max-retries` is still respected