### PR TITLE
fix: correct typo 'ceritficate' to 'certificate' in error messages

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -148,7 +148,7 @@ func tokenFromCli(cmd *cobra.Command) (storage.Token, error) {
 	if certPath != "" {
 		certBytes, err = os.ReadFile(certPath)
 		if err != nil {
-			return storage.Token{}, fmt.Errorf("failed to read ceritficate: %w", err)
+			return storage.Token{}, fmt.Errorf("failed to read certificate: %w", err)
 		}
 	}
 

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -141,7 +141,7 @@ func contextSetCmdFunc(cmd *cobra.Command, args []string) error {
 	if certPath != "" {
 		certBytes, err = os.ReadFile(certPath)
 		if err != nil {
-			return fmt.Errorf("failed to read ceritficate: %w", err)
+			return fmt.Errorf("failed to read certificate: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary
Fixes typo in error messages when certificate file reading fails.

## Changes
Corrected spelling from 'ceritficate' to 'certificate' in two error messages:
- internal/client/client.go:151
- internal/cmd/context.go:144

## Impact
No functional changes, just improves professionalism of CLI error output.

## Test Plan
- All existing tests pass
- No behavioral changes