### PR TITLE
fix: convert global command variables to local instances

### DIFF
--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -49,8 +49,8 @@ func withErrorHandling(f cobraRunEFunc) cobraRunEFunc {
 	}
 }
 
-var (
-	backupCmd = &cobra.Command{
+func registerBackupCmd(rootCmd *cobra.Command) {
+	backupCmd := &cobra.Command{
 		Use:   "backup <filename>",
 		Short: "Create, restore, and inspect permissions system backups",
 		Args:  commands.ValidationWrapper(cobra.MaximumNArgs(1)),
@@ -58,21 +58,21 @@ var (
 		RunE: withErrorHandling(backupCreateCmdFunc),
 	}
 
-	backupCreateCmd = &cobra.Command{
+	backupCreateCmd := &cobra.Command{
 		Use:   "create <filename>",
 		Short: "Backup a permission system to a file",
 		Args:  commands.ValidationWrapper(cobra.MaximumNArgs(1)),
 		RunE:  withErrorHandling(backupCreateCmdFunc),
 	}
 
-	backupRestoreCmd = &cobra.Command{
+	backupRestoreCmd := &cobra.Command{
 		Use:   "restore <filename>",
 		Short: "Restore a permission system from a file",
 		Args:  commands.ValidationWrapper(commands.StdinOrExactArgs(1)),
 		RunE:  backupRestoreCmdFunc,
 	}
 
-	backupParseSchemaCmd = &cobra.Command{
+	backupParseSchemaCmd := &cobra.Command{
 		Use:   "parse-schema <filename>",
 		Short: "Extract the schema from a backup file",
 		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
@@ -81,7 +81,7 @@ var (
 		},
 	}
 
-	backupParseRevisionCmd = &cobra.Command{
+	backupParseRevisionCmd := &cobra.Command{
 		Use:   "parse-revision <filename>",
 		Short: "Extract the revision from a backup file",
 		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
@@ -90,7 +90,7 @@ var (
 		},
 	}
 
-	backupParseRelsCmd = &cobra.Command{
+	backupParseRelsCmd := &cobra.Command{
 		Use:   "parse-relationships <filename>",
 		Short: "Extract the relationships from a backup file",
 		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
@@ -99,7 +99,7 @@ var (
 		},
 	}
 
-	backupRedactCmd = &cobra.Command{
+	backupRedactCmd := &cobra.Command{
 		Use:   "redact <filename>",
 		Short: "Redact a backup file to remove sensitive information",
 		Args:  commands.ValidationWrapper(cobra.ExactArgs(1)),
@@ -107,9 +107,7 @@ var (
 			return backupRedactCmdFunc(cmd, args)
 		},
 	}
-)
 
-func registerBackupCmd(rootCmd *cobra.Command) {
 	rootCmd.AddCommand(backupCmd)
 	registerBackupCreateFlags(backupCmd)
 

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -116,7 +116,6 @@ zed permission check --explain document:firstdoc writer user:emilia
 	registerImportCmd(rootCmd)
 	registerValidateCmd(rootCmd)
 	registerBackupCmd(rootCmd)
-	registerPreviewCmd(rootCmd)
 	registerMCPCmd(rootCmd)
 
 	// Register shared commands.
@@ -128,7 +127,8 @@ zed permission check --explain document:firstdoc writer user:emilia
 	commands.RegisterWatchRelationshipCmd(relCmd)
 
 	schemaCmd := commands.RegisterSchemaCmd(rootCmd)
-	registerAdditionalSchemaCmds(schemaCmd)
+	schemaCompileCmd := registerAdditionalSchemaCmds(schemaCmd)
+	registerPreviewCmd(rootCmd, schemaCompileCmd)
 
 	return rootCmd
 }

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -16,54 +16,52 @@ import (
 )
 
 func registerContextCmd(rootCmd *cobra.Command) {
-	rootCmd.AddCommand(contextCmd)
+	contextCmd := &cobra.Command{
+		Use:     "context <subcommand>",
+		Short:   "Manage configurations for connecting to SpiceDB deployments",
+		Aliases: []string{"ctx"},
+	}
 
+	contextListCmd := &cobra.Command{
+		Use:               "list",
+		Short:             "Lists all available contexts",
+		Aliases:           []string{"ls"},
+		Args:              commands.ValidationWrapper(cobra.ExactArgs(0)),
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              contextListCmdFunc,
+	}
+
+	contextSetCmd := &cobra.Command{
+		Use:               "set <name> <endpoint> <api-token>",
+		Short:             "Creates or overwrite a context",
+		Args:              commands.ValidationWrapper(cobra.ExactArgs(3)),
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              contextSetCmdFunc,
+	}
+
+	contextRemoveCmd := &cobra.Command{
+		Use:               "remove <system>",
+		Short:             "Removes a context",
+		Aliases:           []string{"rm"},
+		Args:              commands.ValidationWrapper(cobra.ExactArgs(1)),
+		ValidArgsFunction: ContextGet,
+		RunE:              contextRemoveCmdFunc,
+	}
+
+	contextUseCmd := &cobra.Command{
+		Use:               "use <system>",
+		Short:             "Sets a context as the current context",
+		Args:              commands.ValidationWrapper(cobra.MaximumNArgs(1)),
+		ValidArgsFunction: ContextGet,
+		RunE:              contextUseCmdFunc,
+	}
+
+	rootCmd.AddCommand(contextCmd)
 	contextCmd.AddCommand(contextListCmd)
 	contextListCmd.Flags().Bool("reveal-tokens", false, "display secrets in results")
-
 	contextCmd.AddCommand(contextSetCmd)
 	contextCmd.AddCommand(contextRemoveCmd)
 	contextCmd.AddCommand(contextUseCmd)
-}
-
-var contextCmd = &cobra.Command{
-	Use:     "context <subcommand>",
-	Short:   "Manage configurations for connecting to SpiceDB deployments",
-	Aliases: []string{"ctx"},
-}
-
-var contextListCmd = &cobra.Command{
-	Use:               "list",
-	Short:             "Lists all available contexts",
-	Aliases:           []string{"ls"},
-	Args:              commands.ValidationWrapper(cobra.ExactArgs(0)),
-	ValidArgsFunction: cobra.NoFileCompletions,
-	RunE:              contextListCmdFunc,
-}
-
-var contextSetCmd = &cobra.Command{
-	Use:               "set <name> <endpoint> <api-token>",
-	Short:             "Creates or overwrite a context",
-	Args:              commands.ValidationWrapper(cobra.ExactArgs(3)),
-	ValidArgsFunction: cobra.NoFileCompletions,
-	RunE:              contextSetCmdFunc,
-}
-
-var contextRemoveCmd = &cobra.Command{
-	Use:               "remove <system>",
-	Short:             "Removes a context",
-	Aliases:           []string{"rm"},
-	Args:              commands.ValidationWrapper(cobra.ExactArgs(1)),
-	ValidArgsFunction: ContextGet,
-	RunE:              contextRemoveCmdFunc,
-}
-
-var contextUseCmd = &cobra.Command{
-	Use:               "use <system>",
-	Short:             "Sets a context as the current context",
-	Args:              commands.ValidationWrapper(cobra.MaximumNArgs(1)),
-	ValidArgsFunction: ContextGet,
-	RunE:              contextUseCmdFunc,
 }
 
 func ContextGet(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -22,18 +22,10 @@ import (
 )
 
 func registerImportCmd(rootCmd *cobra.Command) {
-	rootCmd.AddCommand(importCmd)
-	importCmd.Flags().Int("batch-size", 1000, "import batch size")
-	importCmd.Flags().Int("workers", 1, "number of concurrent batching workers")
-	importCmd.Flags().Bool("schema", true, "import schema")
-	importCmd.Flags().Bool("relationships", true, "import relationships")
-	importCmd.Flags().String("schema-definition-prefix", "", "prefix to add to the schema's definition(s) before importing")
-}
-
-var importCmd = &cobra.Command{
-	Use:   "import <url>",
-	Short: "Imports schema and relationships from a file or url",
-	Example: `
+	importCmd := &cobra.Command{
+		Use:   "import <url>",
+		Short: "Imports schema and relationships from a file or url",
+		Example: `
 	From a gist:
 		zed import https://gist.github.com/ecordell/8e3b613a677e3c844742cf24421c08b6
 
@@ -61,8 +53,16 @@ var importCmd = &cobra.Command{
 	With schema definition prefix:
 		zed import --schema-definition-prefix=mypermsystem file:///Users/zed/Downloads/authzed-x7izWU8_2Gw3.yaml
 `,
-	Args: commands.ValidationWrapper(cobra.ExactArgs(1)),
-	RunE: importCmdFunc,
+		Args: commands.ValidationWrapper(cobra.ExactArgs(1)),
+		RunE: importCmdFunc,
+	}
+
+	rootCmd.AddCommand(importCmd)
+	importCmd.Flags().Int("batch-size", 1000, "import batch size")
+	importCmd.Flags().Int("workers", 1, "number of concurrent batching workers")
+	importCmd.Flags().Bool("schema", true, "import schema")
+	importCmd.Flags().Bool("relationships", true, "import relationships")
+	importCmd.Flags().String("schema-definition-prefix", "", "prefix to add to the schema's definition(s) before importing")
 }
 
 func importCmdFunc(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -8,28 +8,27 @@ import (
 )
 
 func registerMCPCmd(rootCmd *cobra.Command) {
-	rootCmd.AddCommand(mcpCmd)
-	mcpCmd.AddCommand(mcpRunCmd)
+	mcpCmd := &cobra.Command{
+		Use:   "mcp <subcommand>",
+		Short: "MCP (Model Context Protocol) server commands",
+		Long: `MCP (Model Context Protocol) server commands.
 
-	mcpRunCmd.Flags().IntP("port", "p", 9999, "port for the HTTP streaming server")
-}
-
-var mcpCmd = &cobra.Command{
-	Use:   "mcp <subcommand>",
-	Short: "MCP (Model Context Protocol) server commands",
-	Long: `MCP (Model Context Protocol) server commands.
-	
 The MCP server provides tooling and resources for developing and debugging SpiceDB schema and relationships. The server runs an in-memory development instance of SpiceDB and does not connect to a running instance of SpiceDB.
 
 To use with Claude Code, run ` + "`zed mcp experimental-run`" + ` to start the SpiceDB Dev MCP server and then run ` + "`claude mcp add --transport http spicedb \"http://localhost:9999/mcp\"`" + ` to add the server to your Claude Code integrations.`,
-}
+	}
 
-var mcpRunCmd = &cobra.Command{
-	Use:               "experimental-run",
-	Short:             "Run the Experimental MCP server",
-	Args:              commands.ValidationWrapper(cobra.ExactArgs(0)),
-	ValidArgsFunction: cobra.NoFileCompletions,
-	RunE:              mcpRunCmdFunc,
+	mcpRunCmd := &cobra.Command{
+		Use:               "experimental-run",
+		Short:             "Run the Experimental MCP server",
+		Args:              commands.ValidationWrapper(cobra.ExactArgs(0)),
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              mcpRunCmdFunc,
+	}
+
+	rootCmd.AddCommand(mcpCmd)
+	mcpCmd.AddCommand(mcpRunCmd)
+	mcpRunCmd.Flags().IntP("port", "p", 9999, "port for the HTTP streaming server")
 }
 
 func mcpRunCmdFunc(cmd *cobra.Command, _ []string) error {

--- a/internal/cmd/preview.go
+++ b/internal/cmd/preview.go
@@ -4,21 +4,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func registerPreviewCmd(rootCmd *cobra.Command) {
+func registerPreviewCmd(rootCmd *cobra.Command, schemaCompileCmd *cobra.Command) {
+	previewCmd := &cobra.Command{
+		Use:   "preview <subcommand>",
+		Short: "Experimental commands that have been made available for preview",
+	}
+
+	schemaCmd := &cobra.Command{
+		Use:        "schema <subcommand>",
+		Short:      "Manage schema for a permissions system",
+		Deprecated: "please use `zed schema compile`",
+	}
+
 	rootCmd.AddCommand(previewCmd)
-
 	previewCmd.AddCommand(schemaCmd)
-
 	schemaCmd.AddCommand(schemaCompileCmd)
-}
-
-var previewCmd = &cobra.Command{
-	Use:   "preview <subcommand>",
-	Short: "Experimental commands that have been made available for preview",
-}
-
-var schemaCmd = &cobra.Command{
-	Use:        "schema <subcommand>",
-	Short:      "Manage schema for a permissions system",
-	Deprecated: "please use `zed schema compile`",
 }

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -48,16 +48,10 @@ var (
 )
 
 func registerValidateCmd(cmd *cobra.Command) {
-	validateCmd.Flags().Bool("force-color", false, "force color code output even in non-tty environments")
-	validateCmd.Flags().Bool("fail-on-warn", false, "treat warnings as errors during validation")
-	validateCmd.Flags().String("schema-type", "", "force validation according to specific schema syntax (\"\", \"composable\", \"standard\")")
-	cmd.AddCommand(validateCmd)
-}
-
-var validateCmd = &cobra.Command{
-	Use:   "validate <validation_file_or_schema_file>",
-	Short: "Validates the given validation file (.yaml, .zaml) or schema file (.zed)",
-	Example: `
+	validateCmd := &cobra.Command{
+		Use:   "validate <validation_file_or_schema_file>",
+		Short: "Validates the given validation file (.yaml, .zaml) or schema file (.zed)",
+		Example: `
 	From a local file (with prefix):
 		zed validate file:///Users/zed/Downloads/authzed-x7izWU8_2Gw3.yaml
 
@@ -75,25 +69,31 @@ var validateCmd = &cobra.Command{
 
 	From a devtools instance:
 		zed validate https://localhost:8443/download`,
-	Args:              commands.ValidationWrapper(cobra.MinimumNArgs(1)),
-	ValidArgsFunction: commands.FileExtensionCompletions("zed", "yaml", "zaml"),
-	PreRunE:           validatePreRunE,
-	RunE: func(cmd *cobra.Command, filenames []string) error {
-		result, shouldExit, err := validateCmdFunc(cmd, filenames)
-		if err != nil {
-			return err
-		}
-		console.Print(result)
-		if shouldExit {
-			os.Exit(1)
-		}
-		return nil
-	},
+		Args:              commands.ValidationWrapper(cobra.MinimumNArgs(1)),
+		ValidArgsFunction: commands.FileExtensionCompletions("zed", "yaml", "zaml"),
+		PreRunE:           validatePreRunE,
+		RunE: func(cmd *cobra.Command, filenames []string) error {
+			result, shouldExit, err := validateCmdFunc(cmd, filenames)
+			if err != nil {
+				return err
+			}
+			console.Print(result)
+			if shouldExit {
+				os.Exit(1)
+			}
+			return nil
+		},
 
-	// A schema that causes the parser/compiler to error will halt execution
-	// of this command with an error. In that case, we want to just display the error,
-	// rather than showing usage for this command.
-	SilenceUsage: true,
+		// A schema that causes the parser/compiler to error will halt execution
+		// of this command with an error. In that case, we want to just display the error,
+		// rather than showing usage for this command.
+		SilenceUsage: true,
+	}
+
+	validateCmd.Flags().Bool("force-color", false, "force color code output even in non-tty environments")
+	validateCmd.Flags().Bool("fail-on-warn", false, "treat warnings as errors during validation")
+	validateCmd.Flags().String("schema-type", "", "force validation according to specific schema syntax (\"\", \"composable\", \"standard\")")
+	cmd.AddCommand(validateCmd)
 }
 
 var validSchemaTypes = []string{"", "standard", "composable"}

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -69,6 +69,61 @@ func consistencyFromCmd(cmd *cobra.Command) (c *v1.Consistency, err error) {
 }
 
 func RegisterPermissionCmd(rootCmd *cobra.Command) *cobra.Command {
+	permissionCmd := &cobra.Command{
+		Use:     "permission <subcommand>",
+		Short:   "Query the permissions in a permissions system",
+		Aliases: []string{"perm"},
+	}
+
+	checkBulkCmd := &cobra.Command{
+		Use:   "bulk <resource:id#permission@subject:id> <resource:id#permission@subject:id> ...",
+		Short: "Check permissions in bulk exist for resource-subject pairs",
+		Args:  ValidationWrapper(cobra.MinimumNArgs(1)),
+		RunE:  checkBulkCmdFunc,
+	}
+
+	checkCmd := &cobra.Command{
+		Use:               "check <resource:id> <permission> <subject:id>",
+		Short:             "Check that a permission exists for a subject",
+		Args:              ValidationWrapper(cobra.ExactArgs(3)),
+		ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectID),
+		RunE:              checkCmdFunc,
+	}
+
+	expandCmd := &cobra.Command{
+		Use:               "expand <permission> <resource:id>",
+		Short:             "Expand the structure of a permission",
+		Args:              ValidationWrapper(cobra.ExactArgs(2)),
+		ValidArgsFunction: cobra.NoFileCompletions,
+		RunE:              expandCmdFunc,
+	}
+
+	lookupResourcesCmd := &cobra.Command{
+		Use:               "lookup-resources <type> <permission> <subject:id>",
+		Short:             "Enumerates the resources of a given type for which the subject has permission",
+		Args:              ValidationWrapper(cobra.ExactArgs(3)),
+		ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
+		RunE:              lookupResourcesCmdFunc,
+	}
+
+	lookupCmd := &cobra.Command{
+		Use:               "lookup <type> <permission> <subject:id>",
+		Short:             "Enumerates the resources of a given type for which the subject has permission",
+		Args:              ValidationWrapper(cobra.ExactArgs(3)),
+		ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
+		RunE:              lookupResourcesCmdFunc,
+		Deprecated:        "prefer lookup-resources",
+		Hidden:            true,
+	}
+
+	lookupSubjectsCmd := &cobra.Command{
+		Use:               "lookup-subjects <resource:id> <permission> <subject_type#optional_subject_relation>",
+		Short:             "Enumerates the subjects of a given type for which the subject has permission on the resource",
+		Args:              ValidationWrapper(cobra.ExactArgs(3)),
+		ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
+		RunE:              lookupSubjectsCmdFunc,
+	}
+
 	rootCmd.AddCommand(permissionCmd)
 
 	permissionCmd.AddCommand(checkCmd)
@@ -118,61 +173,6 @@ func RegisterPermissionCmd(rootCmd *cobra.Command) *cobra.Command {
 	registerConsistencyFlags(lookupSubjectsCmd.Flags())
 
 	return permissionCmd
-}
-
-var permissionCmd = &cobra.Command{
-	Use:     "permission <subcommand>",
-	Short:   "Query the permissions in a permissions system",
-	Aliases: []string{"perm"},
-}
-
-var checkBulkCmd = &cobra.Command{
-	Use:   "bulk <resource:id#permission@subject:id> <resource:id#permission@subject:id> ...",
-	Short: "Check permissions in bulk exist for resource-subject pairs",
-	Args:  ValidationWrapper(cobra.MinimumNArgs(1)),
-	RunE:  checkBulkCmdFunc,
-}
-
-var checkCmd = &cobra.Command{
-	Use:               "check <resource:id> <permission> <subject:id>",
-	Short:             "Check that a permission exists for a subject",
-	Args:              ValidationWrapper(cobra.ExactArgs(3)),
-	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectID),
-	RunE:              checkCmdFunc,
-}
-
-var expandCmd = &cobra.Command{
-	Use:               "expand <permission> <resource:id>",
-	Short:             "Expand the structure of a permission",
-	Args:              ValidationWrapper(cobra.ExactArgs(2)),
-	ValidArgsFunction: cobra.NoFileCompletions,
-	RunE:              expandCmdFunc,
-}
-
-var lookupResourcesCmd = &cobra.Command{
-	Use:               "lookup-resources <type> <permission> <subject:id>",
-	Short:             "Enumerates the resources of a given type for which the subject has permission",
-	Args:              ValidationWrapper(cobra.ExactArgs(3)),
-	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
-	RunE:              lookupResourcesCmdFunc,
-}
-
-var lookupCmd = &cobra.Command{
-	Use:               "lookup <type> <permission> <subject:id>",
-	Short:             "Enumerates the resources of a given type for which the subject has permission",
-	Args:              ValidationWrapper(cobra.ExactArgs(3)),
-	ValidArgsFunction: GetArgs(ResourceType, Permission, SubjectID),
-	RunE:              lookupResourcesCmdFunc,
-	Deprecated:        "prefer lookup-resources",
-	Hidden:            true,
-}
-
-var lookupSubjectsCmd = &cobra.Command{
-	Use:               "lookup-subjects <resource:id> <permission> <subject_type#optional_subject_relation>",
-	Short:             "Enumerates the subjects of a given type for which the subject has permission on the resource",
-	Args:              ValidationWrapper(cobra.ExactArgs(3)),
-	ValidArgsFunction: GetArgs(ResourceID, Permission, SubjectTypeWithOptionalRelation),
-	RunE:              lookupSubjectsCmdFunc,
 }
 
 func checkCmdFunc(cmd *cobra.Command, args []string) error {

--- a/internal/commands/schema.go
+++ b/internal/commands/schema.go
@@ -17,28 +17,25 @@ import (
 )
 
 func RegisterSchemaCmd(rootCmd *cobra.Command) *cobra.Command {
-	rootCmd.AddCommand(schemaCmd)
-
-	schemaCmd.AddCommand(schemaReadCmd)
-	schemaReadCmd.Flags().Bool("json", false, "output as JSON")
-
-	return schemaCmd
-}
-
-var (
-	schemaCmd = &cobra.Command{
+	schemaCmd := &cobra.Command{
 		Use:   "schema <subcommand>",
 		Short: "Manage schema for a permissions system",
 	}
 
-	schemaReadCmd = &cobra.Command{
+	schemaReadCmd := &cobra.Command{
 		Use:               "read",
 		Short:             "Read the schema of a permissions system",
 		Args:              ValidationWrapper(cobra.ExactArgs(0)),
 		ValidArgsFunction: cobra.NoFileCompletions,
 		RunE:              schemaReadCmdFunc,
 	}
-)
+
+	rootCmd.AddCommand(schemaCmd)
+	schemaCmd.AddCommand(schemaReadCmd)
+	schemaReadCmd.Flags().Bool("json", false, "output as JSON")
+
+	return schemaCmd
+}
 
 func schemaReadCmdFunc(cmd *cobra.Command, _ []string) error {
 	client, err := client.NewClient(cmd)

--- a/internal/commands/watch.go
+++ b/internal/commands/watch.go
@@ -28,8 +28,15 @@ var (
 )
 
 func RegisterWatchCmd(rootCmd *cobra.Command) *cobra.Command {
-	rootCmd.AddCommand(watchCmd)
+	watchCmd := &cobra.Command{
+		Use:        "watch [object_types, ...] [start_cursor]",
+		Short:      "Watches the stream of relationship updates and schema updates from the server",
+		Args:       ValidationWrapper(cobra.RangeArgs(0, 2)),
+		RunE:       watchCmdFunc,
+		Deprecated: "please use `zed relationships watch` instead",
+	}
 
+	rootCmd.AddCommand(watchCmd)
 	watchCmd.Flags().StringSliceVar(&watchObjectTypes, "object_types", nil, "optional object types to watch updates for")
 	watchCmd.Flags().StringVar(&watchRevision, "revision", "", "optional revision at which to start watching")
 	watchCmd.Flags().BoolVar(&watchTimestamps, "timestamp", false, "shows timestamp of incoming update events")
@@ -37,27 +44,19 @@ func RegisterWatchCmd(rootCmd *cobra.Command) *cobra.Command {
 }
 
 func RegisterWatchRelationshipCmd(parentCmd *cobra.Command) *cobra.Command {
+	watchRelationshipsCmd := &cobra.Command{
+		Use:   "watch [object_types, ...] [start_cursor]",
+		Short: "Watches the stream of relationship updates and schema updates from the server",
+		Args:  ValidationWrapper(cobra.RangeArgs(0, 2)),
+		RunE:  watchCmdFunc,
+	}
+
 	parentCmd.AddCommand(watchRelationshipsCmd)
 	watchRelationshipsCmd.Flags().StringSliceVar(&watchObjectTypes, "object_types", nil, "optional object types to watch updates for")
 	watchRelationshipsCmd.Flags().StringVar(&watchRevision, "revision", "", "optional revision at which to start watching")
 	watchRelationshipsCmd.Flags().BoolVar(&watchTimestamps, "timestamp", false, "shows timestamp of incoming update events")
 	watchRelationshipsCmd.Flags().StringSliceVar(&watchRelationshipFilters, "filter", nil, "optional filter(s) for the watch stream. Example: `optional_resource_type:optional_resource_id_or_prefix#optional_relation@optional_subject_filter`")
 	return watchRelationshipsCmd
-}
-
-var watchCmd = &cobra.Command{
-	Use:        "watch [object_types, ...] [start_cursor]",
-	Short:      "Watches the stream of relationship updates and schema updates from the server",
-	Args:       ValidationWrapper(cobra.RangeArgs(0, 2)),
-	RunE:       watchCmdFunc,
-	Deprecated: "please use `zed relationships watch` instead",
-}
-
-var watchRelationshipsCmd = &cobra.Command{
-	Use:   "watch [object_types, ...] [start_cursor]",
-	Short: "Watches the stream of relationship updates and schema updates from the server",
-	Args:  ValidationWrapper(cobra.RangeArgs(0, 2)),
-	RunE:  watchCmdFunc,
 }
 
 func watchCmdFunc(cmd *cobra.Command, _ []string) error {


### PR DESCRIPTION
Fixes #556

## Summary

Tests running with `-count=10` would panic with "flag redefined" errors. Package-level `cobra.Command` global variables were reused across test runs, causing flag registration conflicts when `InitialiseRootCmd` was called multiple times in the same process.

## Changes

- Converted all `register*Cmd` functions to create fresh command instances locally instead of relying on global variables
- Modified 13 files (9 in `internal/cmd`, 4 in `internal/commands`)
- Added regression test `TestMultipleInitialiseRootCmd` to verify the fix

## Test Plan

- [x] All tests pass with `go test -race -count=10 ./internal/cmd`
- [x] All tests pass with `go test -race -count=10 ./internal/commands`
- [x] New regression test verifies `InitialiseRootCmd` can be called multiple times
- [x] Commands still function correctly (`zed version --help`, `zed schema --help`)

This ensures `InitialiseRootCmd` is now idempotent and can be called multiple times without panicking.