### PR TITLE
build(deps): bump github.com/ccoveille/go-safecast to v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b
 	github.com/authzed/spicedb v1.45.4
 	github.com/brianvoe/gofakeit/v6 v6.28.0
-	github.com/ccoveille/go-safecast v1.6.1
+	github.com/ccoveille/go-safecast/v2 v2.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.1
@@ -135,6 +135,7 @@ require (
 	github.com/caio/go-tdigest/v4 v4.0.1 // indirect
 	github.com/catenacyber/perfsprint v0.9.1 // indirect
 	github.com/ccojocar/zxcvbn-go v1.0.4 // indirect
+	github.com/ccoveille/go-safecast v1.8.1 // indirect
 	github.com/certifi/gocertifi v0.0.0-20210507211836-431795d63e8d // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charithe/durationcheck v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,10 @@ github.com/catenacyber/perfsprint v0.9.1 h1:5LlTp4RwTooQjJCvGEFV6XksZvWE7wCOUvjD
 github.com/catenacyber/perfsprint v0.9.1/go.mod h1:q//VWC2fWbcdSLEY1R3l8n0zQCDPdE4IjZwyY1HMunM=
 github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNrUcc=
 github.com/ccojocar/zxcvbn-go v1.0.4/go.mod h1:3GxGX+rHmueTUMvm5ium7irpyjmm7ikxYFOSJB21Das=
-github.com/ccoveille/go-safecast v1.6.1 h1:Nb9WMDR8PqhnKCVs2sCB+OqhohwO5qaXtCviZkIff5Q=
-github.com/ccoveille/go-safecast v1.6.1/go.mod h1:QqwNjxQ7DAqY0C721OIO9InMk9zCwcsO7tnRuHytad8=
+github.com/ccoveille/go-safecast v1.8.1 h1:RoucjfYKKcx2lFmIjRjuo8AeX9k/GaZn5SUMHlA3kMw=
+github.com/ccoveille/go-safecast v1.8.1/go.mod h1:QqwNjxQ7DAqY0C721OIO9InMk9zCwcsO7tnRuHytad8=
+github.com/ccoveille/go-safecast/v2 v2.0.0 h1:+5eyITXAUj3wMjad6cRVJKGnC7vDS55zk0INzJagub0=
+github.com/ccoveille/go-safecast/v2 v2.0.0/go.mod h1:JIYA4CAR33blIDuE6fSwCp2sz1oOBahXnvmdBhOAABs=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/internal/cmd/restorer.go
+++ b/internal/cmd/restorer.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ccoveille/go-safecast"
+	"github.com/ccoveille/go-safecast/v2"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/mattn/go-isatty"
 	"github.com/rs/zerolog/log"
@@ -279,7 +279,7 @@ func (r *restorer) commitStream(ctx context.Context, bulkImportClient v1.Permiss
 
 	// it was a successful transaction commit without duplicates
 	if resp != nil {
-		numLoaded, err := safecast.ToUint(resp.NumLoaded)
+		numLoaded, err := safecast.Convert[uint](resp.NumLoaded)
 		if err != nil {
 			return spiceerrors.MustBugf("could not cast numLoaded to uint")
 		}
@@ -289,7 +289,7 @@ func (r *restorer) commitStream(ctx context.Context, bulkImportClient v1.Permiss
 		}
 	}
 
-	writtenAndSkipped, err := safecast.ToInt64(r.writtenRels + r.skippedRels)
+	writtenAndSkipped, err := safecast.Convert[int64](r.writtenRels + r.skippedRels)
 	if err != nil {
 		return fmt.Errorf("too many written and skipped rels for an int64")
 	}

--- a/internal/cmd/restorer_test.go
+++ b/internal/cmd/restorer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ccoveille/go-safecast"
+	"github.com/ccoveille/go-safecast/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -220,7 +220,11 @@ func (m *mockClientForRestore) Send(req *v1.ImportBulkRelationshipsRequest) erro
 
 	for i, rel := range req.Relationships {
 		// This is a gosec115 false positive which should be fixed in a future version.
-		uinti, _ := safecast.ToUint(i)
+		uinti, err := safecast.Convert[uint](i)
+		if err != nil {
+			// just in case to avoid accessing out of bounds in the []string
+			uinti = 0
+		}
 		require.True(m.t, proto.Equal(rel, tuple.MustParseV1Rel(m.expectedRels[((m.receivedBatches-1)*m.requestedBatchSize)+uinti])))
 	}
 

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/ccoveille/go-safecast"
+	"github.com/ccoveille/go-safecast/v2"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/jzelinskie/stringz"
 	"github.com/rs/zerolog/log"
@@ -223,7 +223,7 @@ func schemaCopyCmdFunc(cmd *cobra.Command, args []string) error {
 }
 
 func schemaWriteCmdImpl(cmd *cobra.Command, args []string, client v1.SchemaServiceClient, terminalChecker termChecker) error {
-	stdInFd, err := safecast.ToInt(uint(os.Stdin.Fd()))
+	stdInFd, err := safecast.Convert[int](os.Stdin.Fd())
 	if err != nil {
 		return err
 	}
@@ -363,7 +363,7 @@ func determinePrefixForSchema(ctx context.Context, specifiedPrefix string, clien
 // Compiles an input schema written in the new composable schema syntax
 // and produces it as a fully-realized schema
 func schemaCompileCmdFunc(cmd *cobra.Command, args []string, termChecker termChecker) error {
-	stdOutFd, err := safecast.ToInt(uint(os.Stdout.Fd()))
+	stdOutFd, err := safecast.Convert[int](os.Stdout.Fd())
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ccoveille/go-safecast"
+	"github.com/ccoveille/go-safecast/v2"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/jzelinskie/cobrautil/v2"
 	"github.com/muesli/termenv"
@@ -283,9 +283,16 @@ func outputErrorWithSource(sb *strings.Builder, validateContents []byte, errWith
 
 func outputForLine(sb *strings.Builder, validateContents []byte, oneIndexedLineNumber uint64, sourceCodeString string, oneIndexedColumnPosition uint64) {
 	lines := strings.Split(string(validateContents), "\n")
-	// These should be fine to be zero if the cast fails.
-	intLineNumber, _ := safecast.ToInt(oneIndexedLineNumber)
-	intColumnPosition, _ := safecast.ToInt(oneIndexedColumnPosition)
+	intLineNumber, err := safecast.Convert[int](oneIndexedLineNumber)
+	if err != nil {
+		// It's fine to be zero if the cast fails.
+		intLineNumber = 0
+	}
+	intColumnPosition, err := safecast.Convert[int](oneIndexedColumnPosition)
+	if err != nil {
+		// It's fine to be zero if the cast fails.
+		intColumnPosition = 0
+	}
 	errorLineNumber := intLineNumber - 1
 	for i := errorLineNumber - 3; i < errorLineNumber+3; i++ {
 		if i == errorLineNumber {


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

I'm the owner of https://github.com/ccoVeille/go-safecast

I noticed your CI was broken because of my recent changes to add deprecation warning to some methods.

- https://github.com/ccoVeille/go-safecast/pull/122

Note: I made some slight changes, as I update the returned value in the v2 of my lib
- https://github.com/ccoVeille/go-safecast/pull/120

So I added check on the error to use zero as a fall back to replicate what would do the v1.

Working on your PR helped me to figure things, such as there is a real need for me to support uintptr

- https://github.com/ccoVeille/go-safecast/issues/17

See https://github.com/authzed/zed/blob/022f31a1892a8612e78ab2a5e902b56a99602539/internal/cmd/schema.go#L226

## Testing

<!--
How did you test this and how can reviewers test this?
-->

Launched golangci-lint locally.

Please note, I checked that the gosec issue false positive is still there.

## References

Related #573: fix the issue with linting reporting go-safecast deprecation warning of ToInt

- #573 

Related to 
- https://github.com/ccoVeille/go-safecast/issues/126
-  https://github.com/ccoVeille/go-safecast/pull/122
- https://github.com/authzed/spicedb/pull/2685