### PR TITLE
feat: add --extra-header flag for custom gRPC headers

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -180,6 +180,7 @@ func TestRetries(t *testing.T) {
 		zedtesting.StringFlag{FlagName: "proxy", FlagValue: "", Changed: true},
 		zedtesting.StringFlag{FlagName: "hostname-override", FlagValue: "", Changed: true},
 		zedtesting.IntFlag{FlagName: "max-message-size", FlagValue: 1000, Changed: true},
+		zedtesting.StringSliceFlag{FlagName: "extra-header", FlagValue: []string{}, Changed: false},
 	)
 	dialOpts, err := client.DialOptsFromFlags(cmd, storage.Token{Insecure: &secure})
 	require.NoError(t, err)
@@ -224,6 +225,7 @@ func TestDoesNotRetry(t *testing.T) {
 		zedtesting.StringFlag{FlagName: "proxy", FlagValue: "", Changed: true},
 		zedtesting.StringFlag{FlagName: "hostname-override", FlagValue: "", Changed: true},
 		zedtesting.IntFlag{FlagName: "max-message-size", FlagValue: 1000, Changed: true},
+		zedtesting.StringSliceFlag{FlagName: "extra-header", FlagValue: []string{}, Changed: false},
 	)
 	dialOpts, err := client.DialOptsFromFlags(cmd, storage.Token{Insecure: &secure})
 	require.NoError(t, err)

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -91,6 +91,7 @@ zed permission check --explain document:firstdoc writer user:emilia
 	rootCmd.PersistentFlags().Int("max-message-size", 0, "maximum size *in bytes* (defaults to 4_194_304 bytes ~= 4MB) of a gRPC message that can be sent or received by zed")
 	rootCmd.PersistentFlags().String("proxy", "", "specify a SOCKS5 proxy address")
 	rootCmd.PersistentFlags().Uint("max-retries", 10, "maximum number of sequential retries to attempt when a request fails")
+	rootCmd.PersistentFlags().StringSlice("extra-header", []string{}, "extra header(s) to add to gRPC requests in the format 'key=value' (can be specified multiple times)")
 	_ = rootCmd.PersistentFlags().MarkHidden("debug") // This cannot return its error.
 
 	versionCmd := &cobra.Command{

--- a/internal/testing/test_helpers.go
+++ b/internal/testing/test_helpers.go
@@ -74,6 +74,12 @@ type StringFlag struct {
 	Changed   bool
 }
 
+type StringSliceFlag struct {
+	FlagName  string
+	FlagValue []string
+	Changed   bool
+}
+
 type BoolFlag struct {
 	FlagName  string
 	FlagValue bool
@@ -115,6 +121,9 @@ func CreateTestCobraCommandWithFlagValue(t *testing.T, flagAndValues ...any) *co
 			c.Flag(f.FlagName).Changed = f.Changed
 		case StringFlag:
 			c.Flags().String(f.FlagName, f.FlagValue, "")
+			c.Flag(f.FlagName).Changed = f.Changed
+		case StringSliceFlag:
+			c.Flags().StringSlice(f.FlagName, f.FlagValue, "")
 			c.Flag(f.FlagName).Changed = f.Changed
 		case BoolFlag:
 			c.Flags().Bool(f.FlagName, f.FlagValue, "")


### PR DESCRIPTION
Signed-off-by: Erik Hennings <erik.hennings@freda.com>

<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description
This PR adds support for passing custom headers to gRPC requests via a new `--extra-header` flag.


## Testing

Manual testing

## References

<!--
GitHub Issue, Discord or Slack threads, etc.
-->
