### PR TITLE
chore: pull in lint rules from spicedb

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,26 +4,33 @@ linters:
   enable:
     - "bidichk"
     - "bodyclose"
+    - "depguard"
     - "errcheck"
     - "errname"
     - "errorlint"
+    - "gocritic"
     - "goprintffuncname"
     - "gosec"
     - "govet"
     - "importas"
     - "ineffassign"
     - "makezero"
+    - "perfsprint"
     - "prealloc"
     - "predeclared"
     - "promlinter"
     - "revive"
     - "rowserrcheck"
+    - "spancheck"
     - "staticcheck"
+    - "tagalign"
+    - "testifylint"
+    - "tparallel"
     - "unconvert"
-    - "unused"
     - "usetesting"
     - "wastedassign"
     - "whitespace"
+    - "unused"
   exclusions:
     generated: "lax"
     presets:
@@ -35,12 +42,29 @@ linters:
       - "third_party$"
       - "builtin$"
       - "examples$"
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "k8s.io/utils/strings/slices$"
+              desc: "use github.com/samber/lo"
+    staticcheck:
+      checks:
+        - "all"
 formatters:
   enable:
     - "gci"
+    - "gofmt"
     - "gofumpt"
     - "goimports"
   settings:
+    gofmt:
+      rewrite-rules:
+        - pattern: "interface{}"
+          replacement: "any"
+        - pattern: "a[b:len(a)]"
+          replacement: "a[b:]"
     gci:
       sections:
         - "standard"

--- a/internal/cmd/backup_test.go
+++ b/internal/cmd/backup_test.go
@@ -45,6 +45,7 @@ var testRelationships = []string{
 }
 
 func TestFilterSchemaDefs(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name         string
 		inputSchema  string
@@ -139,6 +140,7 @@ func TestFilterSchemaDefs(t *testing.T) {
 }
 
 func TestBackupParseRelsCmdFunc(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name          string
 		filter        string
@@ -192,6 +194,7 @@ func TestBackupParseRelsCmdFunc(t *testing.T) {
 }
 
 func TestBackupParseRevisionCmdFunc(t *testing.T) {
+	t.Parallel()
 	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t, zedtesting.StringFlag{FlagName: "prefix-filter", FlagValue: "test"})
 	backupName := createTestBackup(t, testSchema, testRelationships)
 	f, err := os.CreateTemp(t.TempDir(), "parse-output")
@@ -209,6 +212,7 @@ func TestBackupParseRevisionCmdFunc(t *testing.T) {
 }
 
 func TestBackupParseSchemaCmdFunc(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		name          string
 		filter        string
@@ -727,8 +731,8 @@ func TestTakeBackupRecoversFromRetryableErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, actualRels, 2, "expecting two rels in the realized list")
-	require.Equal(t, actualRels[0].Resource.ObjectId, "foo")
-	require.Equal(t, actualRels[1].Resource.ObjectId, "bar")
+	require.Equal(t, "foo", actualRels[0].Resource.ObjectId)
+	require.Equal(t, "bar", actualRels[1].Resource.ObjectId)
 
 	client.assertAllRecvCalls()
 }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -183,11 +183,12 @@ func handleError(command *cobra.Command, err error) error {
 		cmdToExecute = command
 	}
 
-	if errors.Is(err, commands.ValidationError{}) {
+	switch {
+	case errors.Is(err, commands.ValidationError{}):
 		_ = flagError(cmdToExecute, err)
-	} else if err != nil && strings.Contains(err.Error(), "unknown command") {
+	case err != nil && strings.Contains(err.Error(), "unknown command"):
 		_ = flagError(cmdToExecute, err)
-	} else if !errors.Is(err, errParsing) {
+	case !errors.Is(err, errParsing):
 		log.Err(err).Msg("terminated with errors")
 	}
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -79,7 +79,7 @@ func TestCommandOutput(t *testing.T) {
 			if tt.expectStdErrorMsg != "" {
 				require.Contains(t, string(stdErrBytes), tt.expectStdErrorMsg)
 			} else {
-				require.Len(t, stdErrBytes, 0)
+				require.Empty(t, stdErrBytes)
 			}
 			require.Equal(t, tt.expectFlagErrorCalled, flagErrorCalled)
 		})

--- a/internal/cmd/import_test.go
+++ b/internal/cmd/import_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
@@ -29,7 +30,7 @@ func TestImportCmdHappyPath(t *testing.T) {
 	ctx := t.Context()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
-		require.NoError(srv.Run(ctx))
+		assert.NoError(t, srv.Run(ctx))
 	}()
 	conn, err := srv.GRPCDialContext(ctx)
 	require.NoError(err)
@@ -57,5 +58,5 @@ func TestImportCmdHappyPath(t *testing.T) {
 		Resource:    &v1.ObjectReference{ObjectType: "resource", ObjectId: "1"},
 	})
 	require.NoError(err)
-	require.Equal(resp.Permissionship, v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION)
+	require.Equal(v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, resp.Permissionship)
 }

--- a/internal/cmd/restorer.go
+++ b/internal/cmd/restorer.go
@@ -260,7 +260,7 @@ func (r *restorer) commitStream(ctx context.Context, bulkImportClient v1.Permiss
 		r.writtenRels += numLoaded
 	case conflict && r.conflictStrategy == Fail:
 		r.bar.Describe("conflict detected, aborting restore")
-		return fmt.Errorf("duplicate relationships found")
+		return errors.New("duplicate relationships found")
 	case retryable:
 		r.bar.Describe("retrying after error")
 		r.totalRetries++
@@ -291,7 +291,7 @@ func (r *restorer) commitStream(ctx context.Context, bulkImportClient v1.Permiss
 
 	writtenAndSkipped, err := safecast.Convert[int64](r.writtenRels + r.skippedRels)
 	if err != nil {
-		return fmt.Errorf("too many written and skipped rels for an int64")
+		return errors.New("too many written and skipped rels for an int64")
 	}
 
 	if err := r.bar.Set64(writtenAndSkipped); err != nil {

--- a/internal/cmd/restorer_test.go
+++ b/internal/cmd/restorer_test.go
@@ -104,14 +104,17 @@ func TestRestorer(t *testing.T) {
 			expectedRetries := uint(0)
 			var expectsError error
 			for _, err := range tt.commitErrors {
-				if isRetryableError(err) {
-					expectedRetries++
-					if tt.disableRetryErrors {
-						expectsError = err
+				switch {
+				case isRetryableError(err):
+					{
+						expectedRetries++
+						if tt.disableRetryErrors {
+							expectsError = err
+						}
 					}
-				} else if isAlreadyExistsError(err) {
+				case isAlreadyExistsError(err):
 					expectedConflicts++
-				} else {
+				default:
 					expectsError = err
 				}
 			}

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/ccoveille/go-safecast/v2"
@@ -342,7 +343,7 @@ func renderLine(sb *strings.Builder, lines []string, index int, highlight string
 		return
 	}
 
-	lineNumberLength := len(fmt.Sprintf("%d", len(lines)))
+	lineNumberLength := len(strconv.Itoa(len(lines)))
 	lineContents := strings.ReplaceAll(lines[index], "\t", " ")
 	lineDelimiter := "|"
 
@@ -371,7 +372,7 @@ func renderLine(sb *strings.Builder, lines []string, index int, highlight string
 		highlightColumnIndex = highlightStartingColumnIndex
 	}
 
-	lineNumberStr := fmt.Sprintf("%d", index+1)
+	lineNumberStr := strconv.Itoa(index + 1)
 	noNumberSpaces := strings.Repeat(" ", lineNumberLength)
 
 	lineNumberStyle := linePrefixStyle

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -243,11 +243,11 @@ complete - 0 relationships loaded, 0 assertions run, 0 expected relations valida
 				" 11 | \n\n\n",
 		},
 		// TODO: https://github.com/authzed/zed/issues/487
-		//`url_passes`: {
+		// `url_passes`: {
 		//	files: []string{
 		//		"https://play.authzed.com/s/iksdFvCtvnkR/schema",
 		//	},
-		//},
+		// },
 		`composable_schema_passes`: {
 			files: []string{
 				filepath.Join("validate-test", "composable-schema-root.zed"),

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -36,6 +36,7 @@ func TestGetClientVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
 				zedtesting.BoolFlag{FlagName: "include-deps", FlagValue: tt.includeDeps})
 
@@ -47,6 +48,7 @@ func TestGetClientVersion(t *testing.T) {
 }
 
 func TestGetServerVersion(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name                   string
 		serverVersionInHeader  string
@@ -81,6 +83,7 @@ func TestGetServerVersion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t)
 
 			mockClient := &mockSchemaServiceClient{

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -229,7 +230,7 @@ func TestWriteRelationshipsArgs(t *testing.T) {
 	}()
 
 	// returns accepts anything if input file is not a terminal
-	require.Nil(t, StdinOrExactArgs(3)(&cobra.Command{}, nil))
+	require.NoError(t, StdinOrExactArgs(3)(&cobra.Command{}, nil))
 
 	// if both STDIN and CLI args are provided, CLI args take precedence
 	require.ErrorContains(t, StdinOrExactArgs(3)(&cobra.Command{}, []string{"a", "b"}), "accepts 3 arg(s), received 2")
@@ -237,7 +238,7 @@ func TestWriteRelationshipsArgs(t *testing.T) {
 	isTerm = true
 	// checks there is 3 input arguments in case of tty
 	require.ErrorContains(t, StdinOrExactArgs(3)(&cobra.Command{}, nil), "accepts 3 arg(s), received 0")
-	require.Nil(t, StdinOrExactArgs(3)(&cobra.Command{}, []string{"a", "b", "c"}))
+	require.NoError(t, StdinOrExactArgs(3)(&cobra.Command{}, []string{"a", "b", "c"}))
 }
 
 func TestWriteRelationshipCmdFuncFromTTY(t *testing.T) {
@@ -564,6 +565,7 @@ func fileFromStrings(t *testing.T, strings []string) *os.File {
 }
 
 func TestBuildRelationshipsFilter(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		args     []string
@@ -652,7 +654,7 @@ func TestBulkDeleteForcing(t *testing.T) {
 	defer cancel()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
-		require.NoError(t, srv.Run(ctx))
+		assert.NoError(t, srv.Run(ctx))
 	}()
 	conn, err := srv.GRPCDialContext(ctx)
 	require.NoError(t, err)
@@ -702,7 +704,7 @@ func TestBulkDeleteManyForcing(t *testing.T) {
 	defer cancel()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
-		require.NoError(t, srv.Run(ctx))
+		assert.NoError(t, srv.Run(ctx))
 	}()
 	conn, err := srv.GRPCDialContext(ctx)
 	require.NoError(t, err)
@@ -744,7 +746,7 @@ func TestBulkDeleteNotForcing(t *testing.T) {
 	defer cancel()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
-		require.NoError(t, srv.Run(ctx))
+		assert.NoError(t, srv.Run(ctx))
 	}()
 	conn, err := srv.GRPCDialContext(ctx)
 	require.NoError(t, err)

--- a/internal/commands/util.go
+++ b/internal/commands/util.go
@@ -70,7 +70,7 @@ func PrettyProto(m proto.Message) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var obj interface{}
+	var obj any
 	err = json.Unmarshal(encoded, &obj)
 	if err != nil {
 		panic("protojson decode failed: " + err.Error())

--- a/internal/commands/util_test.go
+++ b/internal/commands/util_test.go
@@ -34,7 +34,7 @@ func TestValidationWrapper(t *testing.T) {
 			if tt.wantErr {
 				var validationError ValidationError
 				require.ErrorAs(t, err, &validationError)
-				require.NotNil(t, validationError.error)
+				require.Error(t, validationError.error)
 				require.ErrorContains(t, validationError.error, "accepts at most")
 			} else {
 				require.NoError(t, err)

--- a/internal/decode/decoder_test.go
+++ b/internal/decode/decoder_test.go
@@ -124,7 +124,7 @@ func TestRewriteURL(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			rewriteURL(&tt.in)
-			require.EqualValues(t, tt.out, tt.in)
+			require.Equal(t, tt.out, tt.in)
 		})
 	}
 }

--- a/internal/grpcutil/grpcutil.go
+++ b/internal/grpcutil/grpcutil.go
@@ -31,7 +31,7 @@ var once sync.Once
 func CheckServerVersion(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	callOpts ...grpc.CallOption,
@@ -47,11 +47,12 @@ func CheckServerVersion(
 		versionFromHeader := headerMD.Get(string(responsemeta.ServerVersion))
 		versionFromTrailer := trailerMD.Get(string(responsemeta.ServerVersion))
 		currentVersion := ""
-		if len(versionFromHeader) == 0 && len(versionFromTrailer) == 0 {
+		switch {
+		case len(versionFromHeader) == 0 && len(versionFromTrailer) == 0:
 			log.Debug().Msg("error reading server version response header and trailer; it may be disabled on the server")
-		} else if len(versionFromHeader) == 1 {
+		case len(versionFromHeader) == 1:
 			currentVersion = versionFromHeader[0]
-		} else if len(versionFromTrailer) == 1 {
+		case len(versionFromTrailer) == 1:
 			currentVersion = versionFromTrailer[0]
 		}
 
@@ -101,7 +102,7 @@ func CheckServerVersion(
 func LogDispatchTrailers(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	callOpts ...grpc.CallOption,
@@ -159,7 +160,7 @@ type wrappedStream struct {
 	grpc.ClientStream
 }
 
-func (w *wrappedStream) RecvMsg(m interface{}) error {
+func (w *wrappedStream) RecvMsg(m any) error {
 	err := w.ClientStream.RecvMsg(m)
 	if err != nil && errors.Is(err, io.EOF) {
 		outputDispatchTrailers(w.Trailer())

--- a/internal/mcp/instructions.go
+++ b/internal/mcp/instructions.go
@@ -1,6 +1,10 @@
 package mcp
 
-import "github.com/authzed/zed/internal/schemaexamples"
+import (
+	"strings"
+
+	"github.com/authzed/zed/internal/schemaexamples"
+)
 
 const baseInstructions = `
   You are a helpful AI Agent tasked with helping the user develop, test and iterate on SpiceDB schema (*.zed files) and associated *test* relationship tuples.
@@ -73,17 +77,20 @@ const baseInstructions = `
 `
 
 func buildInstructions() (string, error) {
-	instructions := baseInstructions
+	var instructions strings.Builder
+	instructions.WriteString(baseInstructions)
 
 	examples, err := schemaexamples.ListExampleSchemas()
 	if err != nil {
 		return "", err
 	}
 
-	instructions += "\n  Example schemas you can draw inspiration from include:\n"
+	instructions.WriteString("\n  Example schemas you can draw inspiration from include:\n")
 	for _, example := range examples {
-		instructions += "<example>" + string(example) + "</example>\n"
+		instructions.WriteString("<example>")
+		instructions.Write(example)
+		instructions.WriteString("</example>\n")
 	}
 
-	return instructions, nil
+	return instructions.String(), nil
 }

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -45,7 +45,7 @@ func TestReadSchema(t *testing.T) {
 		schema, err := server.readSchema(ctx)
 
 		// SpiceDB returns an error when no schema is defined, which is expected
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "No schema has been defined")
 		assert.Empty(t, schema)
 	})
@@ -66,7 +66,7 @@ definition user {}`
 		// Now read it back
 		schema, err := server.readSchema(ctx)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedSchema, schema)
 	})
 }
@@ -91,7 +91,7 @@ definition user {}`
 
 		relationships, err := server.readRelationships(ctx)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, relationships)
 	})
 
@@ -139,7 +139,7 @@ definition user {
 
 		relationships, err := server.readRelationships(ctx)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, relationships, 2)
 
 		// Check for expected relationships (order may vary)
@@ -194,7 +194,7 @@ definition user {}`
 
 		contents, err := server.getValidationFileHandler(ctx, request)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, contents, 1)
 
 		content := contents[0].(mcp.TextResourceContents)
@@ -204,7 +204,7 @@ definition user {}`
 		// Parse and verify YAML content
 		var validationFile ValidationFile
 		err = yaml.Unmarshal([]byte(content.Text), &validationFile)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, expectedSchema, validationFile.Schema)
 		assert.Len(t, validationFile.Relationships, 1)
 		assert.Equal(t, "document:doc1#viewer@user:alice", validationFile.Relationships[0])
@@ -234,7 +234,7 @@ definition user {}`
 
 		contents, err := server.getCurrentSchemaHandler(ctx, request)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, contents, 1)
 
 		content := contents[0].(mcp.TextResourceContents)
@@ -285,7 +285,7 @@ definition user {}`
 
 		contents, err := server.getAllRelationshipsHandler(ctx, request)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, contents, 1)
 
 		content := contents[0].(mcp.TextResourceContents)
@@ -311,7 +311,7 @@ definition user {}`
 		// Create mock request
 		request := mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
-				Arguments: map[string]interface{}{
+				Arguments: map[string]any{
 					"schema": schemaText,
 				},
 			},
@@ -319,12 +319,12 @@ definition user {}`
 
 		result, err := server.writeSchemaHandler(ctx, request)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, result)
 
 		// Verify the schema was actually written by reading it back
 		schema, err := server.readSchema(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, schemaText, schema)
 	})
 }
@@ -344,7 +344,7 @@ func TestBuildRelationship(t *testing.T) {
 
 		relationship, err := server.buildRelationship(rel)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "document", relationship.Resource.ObjectType)
 		assert.Equal(t, "doc1", relationship.Resource.ObjectId)
 		assert.Equal(t, "viewer", relationship.Relation)
@@ -365,7 +365,7 @@ func TestBuildRelationship(t *testing.T) {
 
 		relationship, err := server.buildRelationship(rel)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "member", relationship.Subject.OptionalRelation)
 	})
 
@@ -377,12 +377,12 @@ func TestBuildRelationship(t *testing.T) {
 			SubjectType:   "user",
 			SubjectID:     "alice",
 			CaveatName:    "ip_range",
-			CaveatContext: map[string]interface{}{"max_attempts": 3, "enabled": true},
+			CaveatContext: map[string]any{"max_attempts": 3, "enabled": true},
 		}
 
 		relationship, err := server.buildRelationship(rel)
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, relationship.OptionalCaveat)
 		assert.Equal(t, "ip_range", relationship.OptionalCaveat.CaveatName)
 		// Context should be set (not nil) when caveat context is provided
@@ -401,11 +401,11 @@ func TestValidationFileStruct(t *testing.T) {
 		}
 
 		yamlData, err := yaml.Marshal(vf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var parsed ValidationFile
 		err = yaml.Unmarshal(yamlData, &parsed)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, vf.Schema, parsed.Schema)
 		assert.Equal(t, vf.Relationships, parsed.Relationships)
@@ -415,11 +415,11 @@ func TestValidationFileStruct(t *testing.T) {
 		vf := ValidationFile{}
 
 		yamlData, err := yaml.Marshal(vf)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var parsed ValidationFile
 		err = yaml.Unmarshal(yamlData, &parsed)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Empty(t, parsed.Schema)
 		assert.Empty(t, parsed.Relationships)

--- a/internal/printers/debug.go
+++ b/internal/printers/debug.go
@@ -146,14 +146,12 @@ func displayCheckTrace(checkTrace *v1.CheckDebugTrace, tp *TreePrinter, hasError
 		if len(contextMap) > 0 {
 			contextJSON, _ := json.MarshalIndent(contextMap, "", "  ")
 			c.Child(string(contextJSON))
-		} else {
-			if checkTrace.CaveatEvaluationInfo.Result != v1.CaveatEvalInfo_RESULT_MISSING_SOME_CONTEXT {
-				c.Child(faint("(no matching context found)"))
-			}
+		} else if checkTrace.CaveatEvaluationInfo.Result != v1.CaveatEvalInfo_RESULT_MISSING_SOME_CONTEXT {
+			c.Child(faint("(no matching context found)"))
 		}
 
 		if checkTrace.CaveatEvaluationInfo.Result == v1.CaveatEvalInfo_RESULT_MISSING_SOME_CONTEXT {
-			c.Child(fmt.Sprintf("missing context: %s", strings.Join(checkTrace.CaveatEvaluationInfo.PartialCaveatInfo.MissingRequiredContext, ", ")))
+			c.Child("missing context: " + strings.Join(checkTrace.CaveatEvaluationInfo.PartialCaveatInfo.MissingRequiredContext, ", "))
 		}
 	}
 

--- a/internal/storage/config_test.go
+++ b/internal/storage/config_test.go
@@ -33,8 +33,8 @@ func TestTokenWithOverride(t *testing.T) {
 	require.Equal(t, "n1", result.Name)
 	require.Equal(t, "e2", result.Endpoint)
 	require.Equal(t, "a2", result.APIToken)
-	require.Equal(t, false, *result.Insecure)
-	require.Equal(t, false, *result.NoVerifyCA)
+	require.False(t, *result.Insecure)
+	require.False(t, *result.NoVerifyCA)
 	require.Equal(t, 0, bytes.Compare([]byte("c2"), result.CACert))
 
 	result, err = TokenWithOverride(Token{}, referenceToken)
@@ -42,7 +42,7 @@ func TestTokenWithOverride(t *testing.T) {
 	require.Equal(t, "n1", result.Name)
 	require.Equal(t, "e1", result.Endpoint)
 	require.Equal(t, "a1", result.APIToken)
-	require.Equal(t, true, *result.Insecure)
-	require.Equal(t, true, *result.NoVerifyCA)
+	require.True(t, *result.Insecure)
+	require.True(t, *result.NoVerifyCA)
 	require.Equal(t, 0, bytes.Compare([]byte("c1"), result.CACert))
 }

--- a/pkg/backupformat/redaction.go
+++ b/pkg/backupformat/redaction.go
@@ -209,8 +209,7 @@ func redactSchema(schema string, opts RedactionOptions) (string, RedactionMap, e
 						}
 
 						if opts.RedactRelations {
-							switch t := allowedDirect.RelationOrWildcard.(type) {
-							case *core.AllowedRelation_Relation:
+							if t, ok := allowedDirect.RelationOrWildcard.(*core.AllowedRelation_Relation); ok {
 								t.Relation = redactionMap.Relations[t.Relation]
 							}
 						}


### PR DESCRIPTION
## Description
Makes linting in this repo stricter and brings it in line with what we use on SpiceDB.

This also separates out some of the changes from #597.

## Changes
Will annotate.

## Testing
Review. See that tests pass.