### PR TITLE
fix: zed import (#599), also surface errors if they occur

### DIFF
--- a/internal/grpcutil/batch.go
+++ b/internal/grpcutil/batch.go
@@ -3,7 +3,6 @@ package grpcutil
 import (
 	"context"
 	"errors"
-	"fmt"
 	"runtime"
 
 	"golang.org/x/sync/errgroup"
@@ -25,7 +24,7 @@ type EachFunc func(ctx context.Context, no int, start int, end int) error
 // ConcurrentBatch will calculate the minimum number of batches to required to batch n items
 // with batchSize batches. For each batch, it will execute the each function.
 // These functions will be processed in parallel using maxWorkers number of
-// goroutines. If maxWorkers is 1, then batching will happen sychronously. If
+// goroutines. If maxWorkers is 1, then batching will happen synchronously. If
 // maxWorkers is 0, then GOMAXPROCS number of workers will be used.
 //
 // If an error occurs during a batch, all the worker's contexts are cancelled
@@ -53,7 +52,7 @@ func ConcurrentBatch(ctx context.Context, n int, batchSize int, maxWorkers int, 
 	numBatches := (n + batchSize - 1) / batchSize
 	for i := 0; i < numBatches; i++ {
 		if err := sem.Acquire(ctx, 1); err != nil {
-			return fmt.Errorf("failed to acquire semaphore for batch number %d: %w", i, err)
+			break
 		}
 
 		batchNum := i


### PR DESCRIPTION
Before:
```
$ go run ./cmd/zed/main.go import /Users/miparnisari/Documents/GitHub/spicedb/development/schema.yaml
4:31PM WRN not calling a released version of SpiceDB version=db5a5cf56d43-dirty
4:31PM INF importing schema
4:31PM INF importing relationships batch_size=1000 count=10000 workers=1
4:31PM ERR terminated with errors error="failed to acquire semaphore for batch number 1: context canceled"
exit status 1
```

After:
```
$ go run ./cmd/zed/main.go import /Users/miparnisari/Documents/GitHub/spicedb/development/schema.yaml                 
4:31PM WRN not calling a released version of SpiceDB version=db5a5cf56d43-dirty
4:31PM INF importing schema
4:31PM INF importing relationships batch_size=1000 count=10000 workers=1
4:31PM ERR terminated with errors error="rpc error: code = InvalidArgument desc = update count of 1000 is greater than maximum allowed of 500"
exit status 1
```