### PR TITLE
fix: import relationships with caveats and prefix

### DIFF
--- a/internal/cmd/import-test/happy-path-validation-file.yaml
+++ b/internal/cmd/import-test/happy-path-validation-file.yaml
@@ -1,9 +1,12 @@
 ---
 schemaFile: "./happy-path-validation-schema.zed"
-relationships: >-
-  resource:1#user@user:1
+relationships: |-
+  resource:1#reader@user:1[mycaveat]
+  resource:2#writer@user:1
+  resource:3#writer@user:1
 assertions:
   assertTrue:
-    - "resource:1#user@user:1"
+    - 'resource:1#view@user:1 with {"day_of_week":"friday"}'
   assertFalse:
-    - "resource:1#user@user:2"
+    - 'resource:1#view@user:1 with {"day_of_week":"monday"}'
+    - 'resource:1#view@user:2'

--- a/internal/cmd/import-test/happy-path-validation-schema.zed
+++ b/internal/cmd/import-test/happy-path-validation-schema.zed
@@ -1,6 +1,12 @@
 definition user {}
 
+caveat mycaveat(day_of_week string) {
+    day_of_week == "friday"
+}
+
 definition resource {
-  relation user: user
-  permission view = user
+    relation writer: user
+    relation reader: user with mycaveat
+    permission write = writer
+    permission view = reader + write
 }

--- a/internal/cmd/import_test.go
+++ b/internal/cmd/import_test.go
@@ -1,62 +1,104 @@
 package cmd
 
 import (
+	"net/url"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/tuple"
 
-	"github.com/authzed/zed/internal/client"
 	zedtesting "github.com/authzed/zed/internal/testing"
 )
 
 var fullyConsistent = &v1.Consistency{Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true}}
 
-func TestImportCmdHappyPath(t *testing.T) {
-	require := require.New(t)
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
-		zedtesting.StringFlag{FlagName: "schema-definition-prefix"},
-		zedtesting.BoolFlag{FlagName: "schema", FlagValue: true},
-		zedtesting.BoolFlag{FlagName: "relationships", FlagValue: true},
-		zedtesting.IntFlag{FlagName: "batch-size", FlagValue: 100},
-		zedtesting.IntFlag{FlagName: "workers", FlagValue: 1},
-	)
-	f := filepath.Join("import-test", "happy-path-validation-file.yaml")
+func TestImportCmd(t *testing.T) {
+	testcases := map[string]struct {
+		importSchema bool
+		importRels   bool
+		prefix       string
+		check        string
+	}{
+		`without_prefix_import_schema_and_rels`: {
+			prefix:       "",
+			importSchema: true,
+			importRels:   true,
+			check:        `resource:1#view@user:1[mycaveat]`,
+		},
+		`with_prefix_import_schema_and_rels`: {
+			prefix:       "maria",
+			importSchema: true,
+			importRels:   true,
+			check:        `maria/resource:1#view@maria/user:1[maria/mycaveat]`,
+		},
+		`with_prefix_with_slash_import_schema_and_rels`: {
+			prefix:       "maria/",
+			importSchema: true,
+			importRels:   true,
+			check:        `maria/resource:1#view@maria/user:1[maria/mycaveat]`,
+		},
+		`with_prefix_import_only_schema`: {
+			prefix:       "maria",
+			importSchema: true,
+			importRels:   false,
+			check:        "",
+		},
+	}
 
-	// Set up client
-	ctx := t.Context()
-	srv := zedtesting.NewTestServer(ctx, t)
-	go func() {
-		assert.NoError(t, srv.Run(ctx))
-	}()
-	conn, err := srv.GRPCDialContext(ctx)
-	require.NoError(err)
+	for testName, test := range testcases {
+		t.Run(testName, func(t *testing.T) {
+			require := require.New(t)
+			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+				zedtesting.StringFlag{FlagName: "schema-definition-prefix", FlagValue: test.prefix},
+				zedtesting.BoolFlag{FlagName: "schema", FlagValue: test.importSchema},
+				zedtesting.BoolFlag{FlagName: "relationships", FlagValue: test.importRels},
+				zedtesting.IntFlag{FlagName: "batch-size", FlagValue: 100},
+				zedtesting.IntFlag{FlagName: "workers", FlagValue: 1},
+			)
+			f := filepath.Join("import-test", "happy-path-validation-file.yaml")
 
-	originalClient := client.NewClient
-	defer func() {
-		client.NewClient = originalClient
-	}()
+			// Set up client
+			ctx := t.Context()
+			srv := zedtesting.NewTestServer(ctx, t)
+			go func() {
+				assert.NoError(t, srv.Run(ctx))
+			}()
+			conn, err := srv.GRPCDialContext(ctx)
+			require.NoError(err)
 
-	client.NewClient = zedtesting.ClientFromConn(conn)
+			c, err := zedtesting.ClientFromConn(conn)(cmd)
+			require.NoError(err)
 
-	c, err := zedtesting.ClientFromConn(conn)(cmd)
-	require.NoError(err)
+			u, err := url.Parse(f)
+			require.NoError(err)
 
-	// Run the import and assert we don't have errors
-	err = importCmdFunc(cmd, []string{f})
-	require.NoError(err)
+			// Run the import and assert we don't have errors
+			err = importCmdFunc(cmd, c, c, test.prefix, u)
+			require.NoError(err)
 
-	// Run a check with full consistency to see whether the relationships
-	// and schema are written
-	resp, err := c.CheckPermission(ctx, &v1.CheckPermissionRequest{
-		Consistency: fullyConsistent,
-		Subject:     &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: "user", ObjectId: "1"}},
-		Permission:  "view",
-		Resource:    &v1.ObjectReference{ObjectType: "resource", ObjectId: "1"},
-	})
-	require.NoError(err)
-	require.Equal(v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, resp.Permissionship)
+			// Run a check with full consistency to assert that the relationships
+			// and schema were written
+			if test.check != "" {
+				rel := tuple.MustParse(test.check)
+				resp, err := c.CheckPermission(ctx, &v1.CheckPermissionRequest{
+					Consistency: fullyConsistent,
+					Subject:     &v1.SubjectReference{Object: &v1.ObjectReference{ObjectType: rel.Subject.ObjectType, ObjectId: rel.Subject.ObjectID}},
+					Permission:  "view",
+					Resource:    &v1.ObjectReference{ObjectType: rel.Resource.ObjectType, ObjectId: rel.Resource.ObjectID},
+					Context: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"day_of_week": structpb.NewStringValue("friday"),
+						},
+					},
+				})
+				require.NoError(err)
+				require.Equal(v1.CheckPermissionResponse_PERMISSIONSHIP_HAS_PERMISSION, resp.Permissionship)
+			}
+		})
+	}
 }

--- a/internal/cmd/schema.go
+++ b/internal/cmd/schema.go
@@ -285,7 +285,7 @@ func schemaWriteCmdImpl(cmd *cobra.Command, args []string, client v1.SchemaServi
 	return nil
 }
 
-// rewriteSchema rewrites the given existing schema to include the specified prefix on all definitions.
+// rewriteSchema rewrites the given existing schema to include the specified prefix on all definitions and caveats.
 func rewriteSchema(existingSchemaText string, definitionPrefix string) (string, error) {
 	if definitionPrefix == "" {
 		return existingSchemaText, nil


### PR DESCRIPTION
Fixes this:

```shell
~/Documents/GitHub/zed (main) $ ./zed ctx list
 CURRENT  NAME        ENDPOINT              TOKEN                          TLS CERT 
    ✓     serverless  grpc.authzed.com:443  tc_adminclient_def_<redacted>  system   

~/Documents/GitHub/zed (main) $ cat schema.yaml 
---
schema: |+
  definition user {}

  caveat only_on_tuesday(day_of_week string) {
    day_of_week == 'tuesday'
  }

  definition document {
        relation writer: user
        relation reader: user with only_on_tuesday
    permission write = writer
    permission view = reader + write
  }

relationships: |
  document:1#reader@user:1[only_on_tuesday]
  document:2#writer@user:1
  document:3#writer@user:1
  document:4#writer@user:1%                                                                       

~/Documents/GitHub/zed (main) $ ./zed import /Users/miparnisari/Documents/GitHub/zed/schema.yaml  --log-level=debug
7:44PM DBG configured logging async=false format=auto log_level=debug provider=zerolog
7:44PM DBG error reading server version response header and trailer; it may be disabled on the server
7:44PM WRN not calling a released version of SpiceDB version=
7:44PM DBG extracted response dispatch metadata cached=0 dispatch=0
7:44PM DBG found schema definition prefix prefix=maineparnisari
7:44PM INF importing schema
7:44PM DBG extracted response dispatch metadata cached=0 dispatch=0
7:44PM INF importing relationships batch_size=1000 count=4 workers=1
7:44PM DBG extracted response dispatch metadata cached=0 dispatch=0
7:44PM ERR terminated with errors error="rpc error: code = InvalidArgument desc = the length of the unpacked is not equal to the provided input"
```