### PR TITLE
fix: bring in spicedb fix for multiple import behavior

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/TylerBrock/colorjson v0.0.0-20200706003622-8a50f05110d2
 	github.com/authzed/authzed-go v1.7.0
 	github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b
-	github.com/authzed/spicedb v1.48.1-0.20251217214359-3fa88f3893b7
+	github.com/authzed/spicedb v1.48.1-0.20260106174341-5243b5793a43
 	github.com/brianvoe/gofakeit/v6 v6.28.0
 	github.com/ccoveille/go-safecast/v2 v2.0.0
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/go.sum
+++ b/go.sum
@@ -738,8 +738,8 @@ github.com/authzed/ctxkey v0.0.0-20250226155515-d49f99185584 h1:mP7EpcUL90EKcf/F
 github.com/authzed/ctxkey v0.0.0-20250226155515-d49f99185584/go.mod h1:wnimjr5RPPouIhZQ3ztDBLMUKKuUroj3U9Jy0PxeaEE=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b h1:wbh8IK+aMLTCey9sZasO7b6BWLAJnHHvb79fvWCXwxw=
 github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b/go.mod h1:s3qC7V7XIbiNWERv7Lfljy/Lx25/V1Qlexb0WJuA8uQ=
-github.com/authzed/spicedb v1.48.1-0.20251217214359-3fa88f3893b7 h1:ZIx1Lx/U5vvT5g5LKkWz6OjlXm8GeqfSZC71yKf94vk=
-github.com/authzed/spicedb v1.48.1-0.20251217214359-3fa88f3893b7/go.mod h1:8/LnI+Yw6By99u8yf1lkXjFvJQXnLglkx97b5ItA1+0=
+github.com/authzed/spicedb v1.48.1-0.20260106174341-5243b5793a43 h1:t6AkBatxHw5/BdElHmE7mKGAj20lFrMjHXi1LltgQ6w=
+github.com/authzed/spicedb v1.48.1-0.20260106174341-5243b5793a43/go.mod h1:8/LnI+Yw6By99u8yf1lkXjFvJQXnLglkx97b5ItA1+0=
 github.com/aws/aws-sdk-go-v2 v1.40.1 h1:difXb4maDZkRH0x//Qkwcfpdg1XQVXEAEs2DdXldFFc=
 github.com/aws/aws-sdk-go-v2 v1.40.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/config v1.32.3 h1:cpz7H2uMNTDa0h/5CYL5dLUEzPSLo2g0NkbxTRJtSSU=


### PR DESCRIPTION
## Description
Companion to authzed/spicedb#2804. This brings the fix into `zed` so that users can correctly import things with `zed preview schema compile`.

## Changes
* Bring in most recent version of SpiceDB
## Testing
Review.