### PR TITLE
chore: use arm builds in ci

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,7 +13,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   build:
     name: "Build Binary"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "authzed/actions/setup-go@main"
@@ -31,7 +31,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: ["ubuntu-latest"] # TODO(miparnisari): add "windows-latest" after fixing the tests
+        os: ["depot-ubuntu-24.04-arm"] # TODO(miparnisari): add windows after fixing the tests
 
     steps:
       - uses: "actions/checkout@v6"
@@ -48,7 +48,7 @@ jobs:
 
   development:
     name: "WASM Tests"
-    runs-on: "depot-ubuntu-24.04-4"
+    runs-on: "depot-ubuntu-24.04-arm-4"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "authzed/actions/setup-go@main"

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   cla:
     name: "Check Signature"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "authzed/actions/cla-check@main"
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   sync-docs:
     name: "Generate & Sync Documentation"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "authzed/actions/setup-go@main"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ on: # yamllint disable-line rule:truthy
 jobs:
   go-lint:
     name: "Lint Go"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "authzed/actions/setup-go@main"
@@ -24,7 +24,7 @@ jobs:
 
   extra-lint:
     name: "Lint YAML & Markdown"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "authzed/actions/yaml-lint@main"
@@ -34,7 +34,7 @@ jobs:
 
   codeql:
     name: "Analyze with CodeQL"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     permissions:
       actions: "read"
       contents: "read"
@@ -50,7 +50,7 @@ jobs:
 
   trivy-fs:
     name: "Analyze FS with Trivy"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "aquasecurity/trivy-action@master"
@@ -66,7 +66,7 @@ jobs:
 
   trivy-image:
     name: "Analyze Release Image with Trivy"
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "actions/checkout@v6"
       - uses: "authzed/actions/setup-go@main"
@@ -99,7 +99,7 @@ jobs:
 
   conventional-commits:
     name: "Lint Commit Messages"
-    runs-on: "depot-ubuntu-24.04-small"
+    runs-on: "depot-ubuntu-24.04-arm-small"
     if: "github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened' || github.event.action == 'edited')"
     steps:
       - uses: "actions/checkout@v6"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,7 @@ jobs:
                     *Repository:* <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>
 
   docker:
-    runs-on: "ubuntu-latest"
+    runs-on: "depot-ubuntu-24.04-arm"
     steps:
       - uses: "actions/checkout@v6"
         with:


### PR DESCRIPTION
## Description
This seems to have sped things up on the SpiceDB repo so I'm trying it here. I'm also hoping it helps address the WASM flakes we're seeing.

## Changes
* Use depot arm builds in workflows

## Testing
Review.