### PR TITLE
backupformat: strip prefixes w/ empty replacement

### DIFF
--- a/pkg/backupformat/rewriter.go
+++ b/pkg/backupformat/rewriter.go
@@ -184,6 +184,9 @@ type PrefixReplacer struct {
 func (pr *PrefixReplacer) replaceName(name string) string {
 	prefix, prefixlessName, prefixExists := strings.Cut(name, "/")
 	if newPrefix, ok := pr.replacements[prefix]; prefixExists && ok {
+		if newPrefix == "" {
+			return prefixlessName
+		}
 		return newPrefix + "/" + prefixlessName
 	}
 	return name


### PR DESCRIPTION
## Description

This adjusts `zed backup <cmd> --prefix-replacements` flag to support `myprefix=` to strip off a prefix entirely.

## Testing

Easiest way to is to run `zed backup parse-schema --prefix-replacements 'myprefix='` on a backup that has a prefix on it.