### PR TITLE
feat: more debug logging when Watch retries

### DIFF
--- a/internal/commands/watch.go
+++ b/internal/commands/watch.go
@@ -33,7 +33,7 @@ func RegisterWatchCmd(rootCmd *cobra.Command) *cobra.Command {
 		Short:      "Watches the stream of relationship updates and schema updates from the server",
 		Args:       ValidationWrapper(cobra.RangeArgs(0, 2)),
 		RunE:       watchCmdFunc,
-		Deprecated: "please use `zed relationships watch` instead",
+		Deprecated: "please use `zed relationship watch` instead",
 	}
 
 	rootCmd.AddCommand(watchCmd)
@@ -119,16 +119,17 @@ func watchCmdFuncImpl(cmd *cobra.Command, watchClient v1.WatchServiceClient, pro
 		default:
 			resp, err := watchStream.Recv()
 			if err != nil {
+				log.Debug().Err(err).Msg("error receiving from Watch stream")
 				ok, err := isRetryable(err)
 				if !ok {
 					return err
 				}
 
-				log.Trace().Err(err).Msg("will retry from the last known revision " + watchRevision)
+				log.Debug().Err(err).Msg("will retry from the last known revision " + watchRevision)
 				req.OptionalStartCursor = &v1.ZedToken{Token: watchRevision}
 				watchStream, err = watchClient.Watch(ctx, req)
 				if err != nil {
-					return err
+					return fmt.Errorf("error retrying the Watch call: %w", err)
 				}
 				continue
 			}


### PR DESCRIPTION
## Description

Companion to https://github.com/authzed/spicedb/pull/2888

## Testing

1. On tab 1, start SpiceDB
1. On tab 2, `zed watch --log-level=debug`
2. Kill SpiceDB
3. You should see this in `zed`:

```
{"level":"debug","error":"rpc error: code = Unavailable desc = closing transport due to: connection error: desc = \"error reading from server: EOF\", received prior goaway: code: NO_ERROR, debug data: \"graceful_stop\"","time":"2026-02-09T12:17:54-03:00","message":"error receiving from Watch stream"}

{"level":"debug","time":"2026-02-09T12:17:54-03:00","message":"will retry from the last known revision GioKHjE3NzA2NTAyNjgxNDg3MTYwOTYuMDAwMDAwMDAwMBIIYWU5MzAzOTk="}

{"level":"error","error":"error retrying the Watch call: rpc error: code = Unavailable desc = connection error: desc = \"error reading server preface: read tcp 127.0.0.1:64100->127.0.0.1:50051: read: connection reset by peer\"","time":"2026-02-09T12:17:54-03:00","message":"terminated with errors"}
```