### PR TITLE
fix: persist hostname-override flag to context

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -165,12 +165,19 @@ func tokenFromCli(cmd *cobra.Command) (storage.Token, error) {
 		nvc := cobrautil.MustGetBool(cmd, "no-verify-ca")
 		notVerifyCA = &nvc
 	}
+
+	var hostnameOverride string
+	if cmd.Flags().Changed("hostname-override") {
+		hostnameOverride = cobrautil.MustGetString(cmd, "hostname-override")
+	}
+
 	overrideToken := storage.Token{
-		APIToken:   cobrautil.MustGetString(cmd, "token"),
-		Endpoint:   cobrautil.MustGetString(cmd, "endpoint"),
-		Insecure:   notSecure,
-		NoVerifyCA: notVerifyCA,
-		CACert:     certBytes,
+		APIToken:         cobrautil.MustGetString(cmd, "token"),
+		Endpoint:         cobrautil.MustGetString(cmd, "endpoint"),
+		Insecure:         notSecure,
+		NoVerifyCA:       notVerifyCA,
+		CACert:           certBytes,
+		HostnameOverride: hostnameOverride,
 	}
 	return overrideToken, nil
 }
@@ -278,9 +285,8 @@ func DialOptsFromFlags(cmd *cobra.Command, token storage.Token) ([]grpc.DialOpti
 		opts = append(opts, certOpt)
 	}
 
-	hostnameOverride := cobrautil.MustGetString(cmd, "hostname-override")
-	if hostnameOverride != "" {
-		opts = append(opts, grpc.WithAuthority(hostnameOverride))
+	if token.HostnameOverride != "" {
+		opts = append(opts, grpc.WithAuthority(token.HostnameOverride))
 	}
 
 	maxMessageSize := cobrautil.MustGetInt(cmd, "max-message-size")

--- a/internal/cmd/context.go
+++ b/internal/cmd/context.go
@@ -145,14 +145,16 @@ func contextSetCmdFunc(cmd *cobra.Command, args []string) error {
 
 	insecure := cobrautil.MustGetBool(cmd, "insecure")
 	noVerifyCA := cobrautil.MustGetBool(cmd, "no-verify-ca")
+	hostnameOverride := cobrautil.MustGetString(cmd, "hostname-override")
 	cfgStore, secretStore := client.DefaultStorage()
 	err = storage.PutToken(storage.Token{
-		Name:       name,
-		Endpoint:   stringz.DefaultEmpty(endpoint, "grpc.authzed.com:443"),
-		APIToken:   apiToken,
-		Insecure:   &insecure,
-		NoVerifyCA: &noVerifyCA,
-		CACert:     certBytes,
+		Name:             name,
+		Endpoint:         stringz.DefaultEmpty(endpoint, "grpc.authzed.com:443"),
+		APIToken:         apiToken,
+		Insecure:         &insecure,
+		NoVerifyCA:       &noVerifyCA,
+		CACert:           certBytes,
+		HostnameOverride: hostnameOverride,
 	}, secretStore)
 	if err != nil {
 		return err

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -63,12 +63,13 @@ func TokenWithOverride(overrideToken Token, referenceToken Token) (Token, error)
 	}
 
 	return Token{
-		Name:       referenceToken.Name,
-		Endpoint:   stringz.DefaultEmpty(overrideToken.Endpoint, referenceToken.Endpoint),
-		APIToken:   stringz.DefaultEmpty(overrideToken.APIToken, referenceToken.APIToken),
-		Insecure:   insecure,
-		NoVerifyCA: noVerifyCA,
-		CACert:     caCert,
+		Name:             referenceToken.Name,
+		Endpoint:         stringz.DefaultEmpty(overrideToken.Endpoint, referenceToken.Endpoint),
+		APIToken:         stringz.DefaultEmpty(overrideToken.APIToken, referenceToken.APIToken),
+		Insecure:         insecure,
+		NoVerifyCA:       noVerifyCA,
+		CACert:           caCert,
+		HostnameOverride: stringz.DefaultEmpty(overrideToken.HostnameOverride, referenceToken.HostnameOverride),
 	}, nil
 }
 

--- a/internal/storage/config_test.go
+++ b/internal/storage/config_test.go
@@ -10,22 +10,24 @@ import (
 func TestTokenWithOverride(t *testing.T) {
 	bTrue := true
 	referenceToken := Token{
-		Name:       "n1",
-		Endpoint:   "e1",
-		APIToken:   "a1",
-		Insecure:   &bTrue,
-		NoVerifyCA: &bTrue,
-		CACert:     []byte("c1"),
+		Name:             "n1",
+		Endpoint:         "e1",
+		APIToken:         "a1",
+		Insecure:         &bTrue,
+		NoVerifyCA:       &bTrue,
+		CACert:           []byte("c1"),
+		HostnameOverride: "h1",
 	}
 
 	bFalse := false
 	override := Token{
-		Name:       "n2",
-		Endpoint:   "e2",
-		APIToken:   "a2",
-		Insecure:   &bFalse,
-		NoVerifyCA: &bFalse,
-		CACert:     []byte("c2"),
+		Name:             "n2",
+		Endpoint:         "e2",
+		APIToken:         "a2",
+		Insecure:         &bFalse,
+		NoVerifyCA:       &bFalse,
+		CACert:           []byte("c2"),
+		HostnameOverride: "h2",
 	}
 
 	result, err := TokenWithOverride(override, referenceToken)
@@ -36,6 +38,7 @@ func TestTokenWithOverride(t *testing.T) {
 	require.False(t, *result.Insecure)
 	require.False(t, *result.NoVerifyCA)
 	require.Equal(t, 0, bytes.Compare([]byte("c2"), result.CACert))
+	require.Equal(t, "h2", result.HostnameOverride)
 
 	result, err = TokenWithOverride(Token{}, referenceToken)
 	require.NoError(t, err)
@@ -45,4 +48,5 @@ func TestTokenWithOverride(t *testing.T) {
 	require.True(t, *result.Insecure)
 	require.True(t, *result.NoVerifyCA)
 	require.Equal(t, 0, bytes.Compare([]byte("c1"), result.CACert))
+	require.Equal(t, "h1", result.HostnameOverride)
 }

--- a/internal/storage/secrets.go
+++ b/internal/storage/secrets.go
@@ -15,16 +15,17 @@ import (
 )
 
 type Token struct {
-	Name       string
-	Endpoint   string
-	APIToken   string //nolint:gosec // not a hardcoded credential, this is a user-provided API token field
-	Insecure   *bool
-	NoVerifyCA *bool
-	CACert     []byte
+	Name             string
+	Endpoint         string
+	APIToken         string //nolint:gosec // not a hardcoded credential, this is a user-provided API token field
+	Insecure         *bool
+	NoVerifyCA       *bool
+	CACert           []byte
+	HostnameOverride string
 }
 
 func (t Token) AnyValue() bool {
-	if t.Endpoint != "" || t.APIToken != "" || t.Insecure != nil || t.NoVerifyCA != nil || len(t.CACert) > 0 {
+	if t.Endpoint != "" || t.APIToken != "" || t.Insecure != nil || t.NoVerifyCA != nil || len(t.CACert) > 0 || t.HostnameOverride != "" {
 		return true
 	}
 

--- a/internal/storage/secrets_test.go
+++ b/internal/storage/secrets_test.go
@@ -16,4 +16,5 @@ func TestTokenAnyValue(t *testing.T) {
 	require.True(t, Token{Insecure: &b}.AnyValue())
 	require.True(t, Token{NoVerifyCA: &b}.AnyValue())
 	require.True(t, Token{CACert: []byte("a")}.AnyValue())
+	require.True(t, Token{HostnameOverride: "foo"}.AnyValue())
 }


### PR DESCRIPTION
Fixes #593

Persists `--hostname-override` to zed context storage, matching the existing pattern for `--insecure` and `--no-verify-ca`. CLI flag still overrides stored value when explicitly set.