### PR TITLE
chore: use go 1.25.8 to fix vuln

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/authzed/zed
 
-go 1.25.7
+go 1.25.8
 
 // 0.14.0 was published as 1.14.0 by mistake
 retract v1.14.0


### PR DESCRIPTION
Similar to https://github.com/authzed/spicedb/pull/2969