### PR TITLE
chore: get ready to retract versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,10 @@ module github.com/authzed/zed
 
 go 1.26.2
 
-// 0.14.0 was published as 1.14.0 by mistake
-retract v1.14.0
+retract (
+	v1.14.1 // this version retracts itself too
+	v1.14.0 // 0.14.0 was published as 1.14.0 by mistake
+)
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint


### PR DESCRIPTION
thanks to https://github.com/golang/go/issues/74411#issuecomment-3015012663

i think i now how to mark v1.0.0 as the true latest. We will publish a tag for v1.14.1. This will trigger a release, but that's okay, we'll just delete the release.