### PR TITLE
Check HTTP status before parsing response body

### DIFF
--- a/internal/decode/decoder.go
+++ b/internal/decode/decoder.go
@@ -150,6 +150,12 @@ func fetchHTTPDirectly(u *url.URL) ([]byte, error) {
 		return nil, err
 	}
 	defer r.Body.Close()
+
+	if r.StatusCode != http.StatusOK {
+		sanitized := fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Path)
+		return nil, fmt.Errorf("failed to fetch %s: received HTTP %d", sanitized, r.StatusCode)
+	}
+
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err

--- a/internal/decode/decoder_test.go
+++ b/internal/decode/decoder_test.go
@@ -68,6 +68,26 @@ func TestDecoderFromURL(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, schemaContent, vFile.Schema.Schema)
 	})
+
+	t.Run("HTTP 404 returns an error instead of parsing response body", func(t *testing.T) {
+		u, err := url.Parse(serverURL + "/nonexistent")
+		require.NoError(t, err)
+
+		_, err = FetchFromURL(u)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "HTTP 404")
+	})
+
+	t.Run("error message does not leak query parameters", func(t *testing.T) {
+		u, err := url.Parse(serverURL + "/nonexistent?token=secret&key=private")
+		require.NoError(t, err)
+
+		_, err = FetchFromURL(u)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+		require.NotContains(t, err.Error(), "private")
+		require.Contains(t, err.Error(), "/nonexistent")
+	})
 }
 
 func TestRewriteURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- When `zed validate` fetches a URL that returns a non-200 response (e.g. 404), the error page was fed to the schema parser, producing a confusing "invalid yaml" error
- Now checks HTTP status code first and returns a clear error like `failed to fetch ...: received HTTP 404`
- Strips query params from the error URL to avoid leaking tokens

Closes #671