### PR TITLE
feat: add cursor and limit support to relationship read

### DIFF
--- a/docs/zed.md
+++ b/docs/zed.md
@@ -1017,8 +1017,10 @@ zed relationship read <resource_type:optional_resource_id> <optional_relation> <
       --consistency-at-least string     evaluate at least as consistent as the provided zedtoken
       --consistency-full                evaluate at the newest zedtoken in the database
       --consistency-min-latency         evaluate at the zedtoken preferred by the database
+      --cursor string                   resume pagination from a specific cursor token
       --json                            output as JSON
       --page-limit uint32               limit of relations returned per page (default 100)
+      --show-cursor                     display the cursor token after pagination
       --subject-filter string           optional subject filter
 ```
 

--- a/docs/zed.md
+++ b/docs/zed.md
@@ -1019,7 +1019,8 @@ zed relationship read <resource_type:optional_resource_id> <optional_relation> <
       --consistency-min-latency         evaluate at the zedtoken preferred by the database
       --cursor string                   resume pagination from a specific cursor token
       --json                            output as JSON
-      --page-limit uint32               limit of relations returned per page (default 100)
+      --limit uint32                    number of relationships returned in a single request. overrides --page-limit when both are provided.
+      --page-limit uint32               number of relationships queried in each batch when making a no-limit call. used to tune impact on SpiceDB. overridden by --limit when provided (default 100)
       --show-cursor                     display the cursor token after pagination
       --subject-filter string           optional subject filter
 ```

--- a/docs/zed.md
+++ b/docs/zed.md
@@ -1019,7 +1019,7 @@ zed relationship read <resource_type:optional_resource_id> <optional_relation> <
       --consistency-min-latency         evaluate at the zedtoken preferred by the database
       --cursor string                   resume pagination from a specific cursor token
       --json                            output as JSON
-      --limit uint32                    number of relationships returned in a single request. overrides --page-limit when both are provided.
+      --limit uint32                    number of relationships returned in total. overrides --page-limit when both are provided.
       --page-limit uint32               number of relationships queried in each batch when making a no-limit call. used to tune impact on SpiceDB. overridden by --limit when provided (default 100)
       --show-cursor                     display the cursor token after pagination
       --subject-filter string           optional subject filter

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -107,7 +107,7 @@ func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {
 	readCmd.Flags().Bool("json", false, "output as JSON")
 	readCmd.Flags().String("subject-filter", "", "optional subject filter")
 	readCmd.Flags().Uint32("page-limit", 100, "number of relationships queried in each batch when making a no-limit call. used to tune impact on SpiceDB. overridden by --limit when provided")
-	readCmd.Flags().Uint32("limit", 0, "number of relationships returned in a single request. overrides --page-limit when both are provided.")
+	readCmd.Flags().Uint32("limit", 0, "number of relationships returned in total. overrides --page-limit when both are provided.")
 	readCmd.Flags().String("cursor", "", "resume pagination from a specific cursor token")
 	readCmd.Flags().Bool("show-cursor", false, "display the cursor token after pagination")
 	registerConsistencyFlags(readCmd.Flags())

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -107,6 +107,8 @@ func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {
 	readCmd.Flags().Bool("json", false, "output as JSON")
 	readCmd.Flags().String("subject-filter", "", "optional subject filter")
 	readCmd.Flags().Uint32("page-limit", 100, "limit of relations returned per page")
+	readCmd.Flags().String("cursor", "", "resume pagination from a specific cursor token")
+	readCmd.Flags().Bool("show-cursor", false, "display the cursor token after pagination")
 	registerConsistencyFlags(readCmd.Flags())
 
 	relationshipCmd.AddCommand(bulkDeleteCmd)
@@ -278,7 +280,10 @@ func readRelationships(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	lastCursor := request.OptionalCursor
+	var lastCursor *v1.Cursor
+	if cursorStr := cobrautil.MustGetString(cmd, "cursor"); cursorStr != "" {
+		lastCursor = &v1.Cursor{Token: cursorStr}
+	}
 	for {
 		request.OptionalCursor = lastCursor
 		var cursorToken string
@@ -313,16 +318,27 @@ func readRelationships(cmd *cobra.Command, args []string) error {
 			}
 		}
 
+		if newReadRelationshipsPageCallbackForTests != nil {
+			newReadRelationshipsPageCallbackForTests(uint(relCount))
+		}
+
 		if relCount < limit || limit == 0 {
-			return nil
+			break
 		}
 
 		if relCount > limit {
 			log.Warn().Uint32("limit-specified", limit).Uint32("relationships-received", relCount).Msg("page limit ignored, pagination may not be supported by the server, consider updating SpiceDB")
-			return nil
+			break
 		}
 	}
+
+	if cobrautil.MustGetBool(cmd, "show-cursor") && lastCursor != nil {
+		console.Printf("Last cursor: %s\n", lastCursor.Token)
+	}
+	return nil
 }
+
+var newReadRelationshipsPageCallbackForTests func(readByPage uint)
 
 func printRelationship(cmd *cobra.Command, msg *v1.ReadRelationshipsResponse) error {
 	if cobrautil.MustGetBool(cmd, "json") {

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -106,7 +106,8 @@ func RegisterRelationshipCmd(rootCmd *cobra.Command) *cobra.Command {
 	relationshipCmd.AddCommand(readCmd)
 	readCmd.Flags().Bool("json", false, "output as JSON")
 	readCmd.Flags().String("subject-filter", "", "optional subject filter")
-	readCmd.Flags().Uint32("page-limit", 100, "limit of relations returned per page")
+	readCmd.Flags().Uint32("page-limit", 100, "number of relationships queried in each batch when making a no-limit call. used to tune impact on SpiceDB. overridden by --limit when provided")
+	readCmd.Flags().Uint32("limit", 0, "number of relationships returned in a single request. overrides --page-limit when both are provided.")
 	readCmd.Flags().String("cursor", "", "resume pagination from a specific cursor token")
 	readCmd.Flags().Bool("show-cursor", false, "display the cursor token after pagination")
 	registerConsistencyFlags(readCmd.Flags())
@@ -277,7 +278,13 @@ func readRelationshipsImpl(cmd *cobra.Command, args []string, responseHandler fu
 
 	request := &v1.ReadRelationshipsRequest{RelationshipFilter: filter}
 
-	limit := cobrautil.MustGetUint32(cmd, "page-limit")
+	pageSize := cobrautil.MustGetUint32(cmd, "page-limit")
+	limit := cobrautil.MustGetUint32(cmd, "limit")
+	limitSet := limit > 0
+	// If --limit is not set, use --page-size as the per-request limit
+	if !limitSet {
+		limit = pageSize
+	}
 	request.OptionalLimit = limit
 	request.Consistency, err = consistencyFromCmd(cmd)
 	if err != nil {
@@ -325,7 +332,9 @@ func readRelationshipsImpl(cmd *cobra.Command, args []string, responseHandler fu
 			return err
 		}
 
-		if relCount < limit || limit == 0 {
+		// If we set an explicit limit or if we find a page smaller than the page limit,
+		// we stop.
+		if limitSet || relCount < limit {
 			break
 		}
 

--- a/internal/commands/relationship.go
+++ b/internal/commands/relationship.go
@@ -261,6 +261,10 @@ func buildRelationshipsFilter(cmd *cobra.Command, args []string) (*v1.Relationsh
 }
 
 func readRelationships(cmd *cobra.Command, args []string) error {
+	return readRelationshipsImpl(cmd, args, printRelationship)
+}
+
+func readRelationshipsImpl(cmd *cobra.Command, args []string, responseHandler func(cmd *cobra.Command, responses []*v1.ReadRelationshipsResponse) error) error {
 	spicedbClient, err := client.NewClient(cmd)
 	if err != nil {
 		return err
@@ -297,6 +301,7 @@ func readRelationships(cmd *cobra.Command, args []string) error {
 		}
 
 		var relCount uint32
+		responses := make([]*v1.ReadRelationshipsResponse, 0, limit)
 		for {
 			if err := cmd.Context().Err(); err != nil {
 				return err
@@ -311,15 +316,13 @@ func readRelationships(cmd *cobra.Command, args []string) error {
 				return err
 			}
 
+			responses = append(responses, msg)
 			lastCursor = msg.AfterResultCursor
 			relCount++
-			if err := printRelationship(cmd, msg); err != nil {
-				return err
-			}
 		}
 
-		if newReadRelationshipsPageCallbackForTests != nil {
-			newReadRelationshipsPageCallbackForTests(uint(relCount))
+		if err := responseHandler(cmd, responses); err != nil {
+			return err
 		}
 
 		if relCount < limit || limit == 0 {
@@ -338,22 +341,22 @@ func readRelationships(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-var newReadRelationshipsPageCallbackForTests func(readByPage uint)
+func printRelationship(cmd *cobra.Command, responses []*v1.ReadRelationshipsResponse) error {
+	for _, response := range responses {
+		if cobrautil.MustGetBool(cmd, "json") {
+			prettyProto, err := PrettyProto(response)
+			if err != nil {
+				return err
+			}
 
-func printRelationship(cmd *cobra.Command, msg *v1.ReadRelationshipsResponse) error {
-	if cobrautil.MustGetBool(cmd, "json") {
-		prettyProto, err := PrettyProto(msg)
-		if err != nil {
-			return err
+			console.Println(string(prettyProto))
+		} else {
+			relString, err := relationshipToString(response.Relationship)
+			if err != nil {
+				return err
+			}
+			console.Println(relString)
 		}
-
-		console.Println(string(prettyProto))
-	} else {
-		relString, err := relationshipToString(msg.Relationship)
-		if err != nil {
-			return err
-		}
-		console.Println(relString)
 	}
 
 	return nil

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -820,7 +820,7 @@ func assertRelationshipCount(ctx context.Context, t *testing.T, c client.Client,
 	require.Equal(t, count, relCount)
 }
 
-func testReadRelationshipsCommand(t *testing.T, pageLimit uint32, cursor string, showCursor bool) *cobra.Command {
+func testReadRelationshipsCommand(t *testing.T, limit, pageLimit uint32, cursor string, showCursor bool) *cobra.Command {
 	t.Helper()
 	return zedtesting.CreateTestCobraCommandWithFlagValue(t,
 		zedtesting.BoolFlag{FlagName: "consistency-full", FlagValue: true},
@@ -829,6 +829,7 @@ func testReadRelationshipsCommand(t *testing.T, pageLimit uint32, cursor string,
 		zedtesting.StringFlag{FlagName: "consistency-at-exactly"},
 		zedtesting.StringFlag{FlagName: "revision"},
 		zedtesting.StringFlag{FlagName: "subject-filter"},
+		zedtesting.UintFlag32{FlagName: "limit", FlagValue: limit},
 		zedtesting.UintFlag32{FlagName: "page-limit", FlagValue: pageLimit},
 		zedtesting.BoolFlag{FlagName: "json"},
 		zedtesting.StringFlag{FlagName: "cursor", FlagValue: cursor},
@@ -878,20 +879,22 @@ func TestReadRelationshipsCursor(t *testing.T) {
 	_, err = c.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{Updates: updates})
 	require.NoError(t, err)
 
-	t.Run("no page limit returns all in one page", func(t *testing.T) {
+	t.Run("setting limit returns all in one page", func(t *testing.T) {
 		callback, pages := makeTestCallback()
 
-		cmd := testReadRelationshipsCommand(t, 0, "", false)
+		cmd := testReadRelationshipsCommand(t, 5, 100, "", false)
 		err := readRelationshipsImpl(cmd, []string{"test/resource"}, callback)
 		require.NoError(t, err)
 		require.Len(t, *pages, 1, "there should only be one page of results")
-		require.Len(t, (*pages)[0], 10, "there should be 10 results in the page")
+		require.Len(t, (*pages)[0], 5, "there should be 5 results in the page")
 	})
 
+	// When page limit is set and limit is not, it should iterate through all
+	// results using the page size.
 	t.Run("page limit paginates through results", func(t *testing.T) {
 		callback, pages := makeTestCallback()
 
-		cmd := testReadRelationshipsCommand(t, 3, "", false)
+		cmd := testReadRelationshipsCommand(t, 0, 3, "", false)
 		err := readRelationshipsImpl(cmd, []string{"test/resource"}, callback)
 		require.NoError(t, err)
 		require.NoError(t, err)
@@ -914,7 +917,7 @@ func TestReadRelationshipsCursor(t *testing.T) {
 			fmt.Fprintf(&output, format, a...)
 		}
 
-		cmd := testReadRelationshipsCommand(t, 3, "", true)
+		cmd := testReadRelationshipsCommand(t, 5, 100, "", true)
 		err := readRelationships(cmd, []string{"test/resource"})
 		require.NoError(t, err)
 		require.Contains(t, output.String(), "Last cursor: ")
@@ -948,22 +951,22 @@ func TestReadRelationshipsCursor(t *testing.T) {
 		require.NotNil(t, resumeCursor)
 		require.NotEmpty(t, resumeCursor.Token)
 
-		// Now call read with the cursor and confirm only the remaining 6 are emitted.
+		// Now call read with the cursor and confirm only 4 are emitted
 		callback, pages := makeTestCallback()
 
-		cmd := testReadRelationshipsCommand(t, resumePageLimit, resumeCursor.Token, false)
+		cmd := testReadRelationshipsCommand(t, resumePageLimit, 100, resumeCursor.Token, false)
 		err = readRelationshipsImpl(cmd, []string{"test/resource"}, callback)
 		require.NoError(t, err)
-		require.Len(t, *pages, 2)
+		require.Len(t, *pages, 1)
 
 		lengths := slicez.Map(*pages, func(page []*v1.ReadRelationshipsResponse) int {
 			return len(page)
 		})
-		require.Equal(t, []int{4, 2}, lengths)
+		require.Equal(t, []int{4}, lengths)
 	})
 
 	t.Run("invalid cursor returns error", func(t *testing.T) {
-		cmd := testReadRelationshipsCommand(t, 0, "not-a-real-cursor", false)
+		cmd := testReadRelationshipsCommand(t, 0, 100, "not-a-real-cursor", false)
 		err := readRelationships(cmd, []string{"test/resource"})
 		require.Error(t, err)
 	})

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/authzed/spicedb/pkg/tuple"
 
 	"github.com/authzed/zed/internal/client"
+	"github.com/authzed/zed/internal/console"
 	"github.com/authzed/zed/internal/zedtesting"
 )
 
@@ -819,4 +820,167 @@ func assertRelationshipCount(ctx context.Context, t *testing.T, c client.Client,
 
 	require.NoError(t, rrCli.CloseSend())
 	require.Equal(t, count, relCount)
+}
+
+func testReadRelationshipsCommand(t *testing.T, pageLimit uint32, cursor string, showCursor bool) *cobra.Command {
+	t.Helper()
+	return zedtesting.CreateTestCobraCommandWithFlagValue(t,
+		zedtesting.BoolFlag{FlagName: "consistency-full", FlagValue: true},
+		zedtesting.StringFlag{FlagName: "consistency-at-least"},
+		zedtesting.BoolFlag{FlagName: "consistency-min-latency", FlagValue: false},
+		zedtesting.StringFlag{FlagName: "consistency-at-exactly"},
+		zedtesting.StringFlag{FlagName: "revision"},
+		zedtesting.StringFlag{FlagName: "subject-filter"},
+		zedtesting.UintFlag32{FlagName: "page-limit", FlagValue: pageLimit},
+		zedtesting.BoolFlag{FlagName: "json"},
+		zedtesting.StringFlag{FlagName: "cursor", FlagValue: cursor},
+		zedtesting.BoolFlag{FlagName: "show-cursor", FlagValue: showCursor})
+}
+
+func TestReadRelationshipsCursor(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	srv := zedtesting.NewTestServer(ctx, t)
+	go func() {
+		assert.NoError(t, srv.Run(ctx))
+	}()
+	conn, err := srv.GRPCDialContext(ctx)
+	require.NoError(t, err)
+
+	originalClient := client.NewClient
+	defer func() {
+		client.NewClient = originalClient
+	}()
+
+	client.NewClient = zedtesting.ClientFromConn(conn)
+
+	c, err := zedtesting.ClientFromConn(conn)(nil)
+	require.NoError(t, err)
+
+	_, err = c.WriteSchema(ctx, &v1.WriteSchemaRequest{Schema: testSchema})
+	require.NoError(t, err)
+
+	var updates []*v1.RelationshipUpdate
+	for i := 0; i < 10; i++ {
+		updates = append(updates, &v1.RelationshipUpdate{
+			Operation:    v1.RelationshipUpdate_OPERATION_TOUCH,
+			Relationship: tuple.MustParseV1Rel(fmt.Sprintf("test/resource:%d#reader@test/user:1", i)),
+		})
+	}
+	_, err = c.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{Updates: updates})
+	require.NoError(t, err)
+
+	previousPrintln := console.Println
+	previousPrintf := console.Printf
+	defer func() {
+		console.Println = previousPrintln
+		console.Printf = previousPrintf
+	}()
+	var printedLines []string
+	console.Println = func(values ...any) {
+		for _, v := range values {
+			printedLines = append(printedLines, fmt.Sprint(v))
+		}
+	}
+	var printedFormatted []string
+	console.Printf = func(format string, a ...any) {
+		printedFormatted = append(printedFormatted, fmt.Sprintf(format, a...))
+	}
+
+	var receivedPageSizes []uint
+	newReadRelationshipsPageCallbackForTests = func(readPageSize uint) {
+		receivedPageSizes = append(receivedPageSizes, readPageSize)
+	}
+	defer func() {
+		newReadRelationshipsPageCallbackForTests = nil
+	}()
+
+	t.Run("no page limit returns all in one page", func(t *testing.T) {
+		printedLines = nil
+		printedFormatted = nil
+		receivedPageSizes = nil
+
+		cmd := testReadRelationshipsCommand(t, 0, "", false)
+		err := readRelationships(cmd, []string{"test/resource"})
+		require.NoError(t, err)
+		require.Len(t, printedLines, 10)
+		require.Equal(t, []uint{10}, receivedPageSizes)
+		require.Empty(t, printedFormatted)
+	})
+
+	t.Run("page limit paginates through results", func(t *testing.T) {
+		printedLines = nil
+		printedFormatted = nil
+		receivedPageSizes = nil
+
+		cmd := testReadRelationshipsCommand(t, 3, "", false)
+		err := readRelationships(cmd, []string{"test/resource"})
+		require.NoError(t, err)
+		require.Len(t, printedLines, 10)
+		require.Equal(t, []uint{3, 3, 3, 1}, receivedPageSizes)
+	})
+
+	t.Run("show-cursor prints last cursor", func(t *testing.T) {
+		printedLines = nil
+		printedFormatted = nil
+		receivedPageSizes = nil
+
+		cmd := testReadRelationshipsCommand(t, 3, "", true)
+		err := readRelationships(cmd, []string{"test/resource"})
+		require.NoError(t, err)
+		require.Len(t, printedLines, 10)
+		require.Len(t, printedFormatted, 1)
+		require.Contains(t, printedFormatted[0], "Last cursor: ")
+		require.NotEqual(t, "Last cursor: \n", printedFormatted[0])
+	})
+
+	t.Run("starting cursor resumes pagination", func(t *testing.T) {
+		// First, fetch the cursor after the first page using the same page-limit
+		// the resume call will use (the cursor must match the original API call).
+		const resumePageLimit uint32 = 4
+		stream, err := c.ReadRelationships(ctx, &v1.ReadRelationshipsRequest{
+			Consistency: &v1.Consistency{
+				Requirement: &v1.Consistency_FullyConsistent{FullyConsistent: true},
+			},
+			RelationshipFilter: &v1.RelationshipFilter{ResourceType: "test/resource"},
+			OptionalLimit:      resumePageLimit,
+		})
+		require.NoError(t, err)
+
+		var resumeCursor *v1.Cursor
+		var firstPageSeen int
+		for {
+			msg, err := stream.Recv()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			require.NoError(t, err)
+			firstPageSeen++
+			resumeCursor = msg.AfterResultCursor
+		}
+		require.Equal(t, int(resumePageLimit), firstPageSeen)
+		require.NotNil(t, resumeCursor)
+		require.NotEmpty(t, resumeCursor.Token)
+
+		// Now call read with the cursor and confirm only the remaining 6 are emitted.
+		printedLines = nil
+		printedFormatted = nil
+		receivedPageSizes = nil
+
+		cmd := testReadRelationshipsCommand(t, resumePageLimit, resumeCursor.Token, false)
+		err = readRelationships(cmd, []string{"test/resource"})
+		require.NoError(t, err)
+		require.Len(t, printedLines, 6)
+		require.Equal(t, []uint{4, 2}, receivedPageSizes)
+	})
+
+	t.Run("invalid cursor returns error", func(t *testing.T) {
+		printedLines = nil
+		printedFormatted = nil
+		receivedPageSizes = nil
+
+		cmd := testReadRelationshipsCommand(t, 0, "not-a-real-cursor", false)
+		err := readRelationships(cmd, []string{"test/resource"})
+		require.Error(t, err)
+	})
 }

--- a/internal/commands/relationship_test.go
+++ b/internal/commands/relationship_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
+	"github.com/authzed/spicedb/pkg/genutil/slicez"
 	"github.com/authzed/spicedb/pkg/tuple"
 
 	"github.com/authzed/zed/internal/client"
@@ -648,8 +649,7 @@ func (m *mockClient) WriteRelationships(_ context.Context, in *v1.WriteRelations
 }
 
 func TestBulkDeleteForcing(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
 		assert.NoError(t, srv.Run(ctx))
@@ -698,8 +698,7 @@ func TestBulkDeleteForcing(t *testing.T) {
 }
 
 func TestBulkDeleteManyForcing(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
 		assert.NoError(t, srv.Run(ctx))
@@ -740,8 +739,7 @@ func TestBulkDeleteManyForcing(t *testing.T) {
 }
 
 func TestBulkDeleteNotForcing(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
 		assert.NoError(t, srv.Run(ctx))
@@ -837,9 +835,19 @@ func testReadRelationshipsCommand(t *testing.T, pageLimit uint32, cursor string,
 		zedtesting.BoolFlag{FlagName: "show-cursor", FlagValue: showCursor})
 }
 
+// makeTestCallback is a convenience function that returns a callback and a pointer to
+// the slice it modifies.
+func makeTestCallback() (func(_ *cobra.Command, responses []*v1.ReadRelationshipsResponse) error, *[][]*v1.ReadRelationshipsResponse) {
+	var pages [][]*v1.ReadRelationshipsResponse
+	callback := func(_ *cobra.Command, responses []*v1.ReadRelationshipsResponse) error {
+		pages = append(pages, responses)
+		return nil
+	}
+	return callback, &pages
+}
+
 func TestReadRelationshipsCursor(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	defer cancel()
+	ctx := t.Context()
 	srv := zedtesting.NewTestServer(ctx, t)
 	go func() {
 		assert.NoError(t, srv.Run(ctx))
@@ -870,68 +878,46 @@ func TestReadRelationshipsCursor(t *testing.T) {
 	_, err = c.WriteRelationships(ctx, &v1.WriteRelationshipsRequest{Updates: updates})
 	require.NoError(t, err)
 
-	previousPrintln := console.Println
-	previousPrintf := console.Printf
-	defer func() {
-		console.Println = previousPrintln
-		console.Printf = previousPrintf
-	}()
-	var printedLines []string
-	console.Println = func(values ...any) {
-		for _, v := range values {
-			printedLines = append(printedLines, fmt.Sprint(v))
-		}
-	}
-	var printedFormatted []string
-	console.Printf = func(format string, a ...any) {
-		printedFormatted = append(printedFormatted, fmt.Sprintf(format, a...))
-	}
-
-	var receivedPageSizes []uint
-	newReadRelationshipsPageCallbackForTests = func(readPageSize uint) {
-		receivedPageSizes = append(receivedPageSizes, readPageSize)
-	}
-	defer func() {
-		newReadRelationshipsPageCallbackForTests = nil
-	}()
-
 	t.Run("no page limit returns all in one page", func(t *testing.T) {
-		printedLines = nil
-		printedFormatted = nil
-		receivedPageSizes = nil
+		callback, pages := makeTestCallback()
 
 		cmd := testReadRelationshipsCommand(t, 0, "", false)
-		err := readRelationships(cmd, []string{"test/resource"})
+		err := readRelationshipsImpl(cmd, []string{"test/resource"}, callback)
 		require.NoError(t, err)
-		require.Len(t, printedLines, 10)
-		require.Equal(t, []uint{10}, receivedPageSizes)
-		require.Empty(t, printedFormatted)
+		require.Len(t, *pages, 1, "there should only be one page of results")
+		require.Len(t, (*pages)[0], 10, "there should be 10 results in the page")
 	})
 
 	t.Run("page limit paginates through results", func(t *testing.T) {
-		printedLines = nil
-		printedFormatted = nil
-		receivedPageSizes = nil
+		callback, pages := makeTestCallback()
 
 		cmd := testReadRelationshipsCommand(t, 3, "", false)
-		err := readRelationships(cmd, []string{"test/resource"})
+		err := readRelationshipsImpl(cmd, []string{"test/resource"}, callback)
 		require.NoError(t, err)
-		require.Len(t, printedLines, 10)
-		require.Equal(t, []uint{3, 3, 3, 1}, receivedPageSizes)
+		require.NoError(t, err)
+		require.Len(t, *pages, 4, "there should be four pages of results")
+
+		lengths := slicez.Map(*pages, func(page []*v1.ReadRelationshipsResponse) int {
+			return len(page)
+		})
+		require.Equal(t, []int{3, 3, 3, 1}, lengths)
 	})
 
 	t.Run("show-cursor prints last cursor", func(t *testing.T) {
-		printedLines = nil
-		printedFormatted = nil
-		receivedPageSizes = nil
+		originalPrint := console.Printf
+		defer func() {
+			console.Printf = originalPrint
+		}()
+
+		var output strings.Builder
+		console.Printf = func(format string, a ...any) {
+			fmt.Fprintf(&output, format, a...)
+		}
 
 		cmd := testReadRelationshipsCommand(t, 3, "", true)
 		err := readRelationships(cmd, []string{"test/resource"})
 		require.NoError(t, err)
-		require.Len(t, printedLines, 10)
-		require.Len(t, printedFormatted, 1)
-		require.Contains(t, printedFormatted[0], "Last cursor: ")
-		require.NotEqual(t, "Last cursor: \n", printedFormatted[0])
+		require.Contains(t, output.String(), "Last cursor: ")
 	})
 
 	t.Run("starting cursor resumes pagination", func(t *testing.T) {
@@ -963,22 +949,20 @@ func TestReadRelationshipsCursor(t *testing.T) {
 		require.NotEmpty(t, resumeCursor.Token)
 
 		// Now call read with the cursor and confirm only the remaining 6 are emitted.
-		printedLines = nil
-		printedFormatted = nil
-		receivedPageSizes = nil
+		callback, pages := makeTestCallback()
 
 		cmd := testReadRelationshipsCommand(t, resumePageLimit, resumeCursor.Token, false)
-		err = readRelationships(cmd, []string{"test/resource"})
+		err = readRelationshipsImpl(cmd, []string{"test/resource"}, callback)
 		require.NoError(t, err)
-		require.Len(t, printedLines, 6)
-		require.Equal(t, []uint{4, 2}, receivedPageSizes)
+		require.Len(t, *pages, 2)
+
+		lengths := slicez.Map(*pages, func(page []*v1.ReadRelationshipsResponse) int {
+			return len(page)
+		})
+		require.Equal(t, []int{4, 2}, lengths)
 	})
 
 	t.Run("invalid cursor returns error", func(t *testing.T) {
-		printedLines = nil
-		printedFormatted = nil
-		receivedPageSizes = nil
-
 		cmd := testReadRelationshipsCommand(t, 0, "not-a-real-cursor", false)
 		err := readRelationships(cmd, []string{"test/resource"})
 		require.Error(t, err)


### PR DESCRIPTION
 Adds `--cursor` and `--show-cursor` flags to `zed relationship read` so users can resume pagination from a prior cursor token and surface the trailing cursor for follow-up calls. 