### PR TITLE
chore: apply gofumpt formatting

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -31,7 +31,8 @@ func TestGetTokenWithCLIOverride(t *testing.T) {
 	})
 	_, err = testCert.Write([]byte("hi"))
 	require.NoError(err)
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.StringFlag{FlagName: "token", FlagValue: "t1", Changed: true},
 		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: testCert.Name(), Changed: true},
 		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: "e1", Changed: true},
@@ -53,7 +54,8 @@ func TestGetTokenWithCLIOverride(t *testing.T) {
 	require.Equal(&bTrue, to.NoVerifyCA)
 
 	// storage token takes precedence when defined
-	cmd = zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd = zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.StringFlag{FlagName: "token", FlagValue: "", Changed: false},
 		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: "", Changed: false},
 		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: "", Changed: false},
@@ -80,7 +82,8 @@ func TestGetCurrentTokenWithCLIOverrideWithoutConfigFile(t *testing.T) {
 	// When we refactored the token setting logic, we broke the workflow where zed is used without a saved
 	// configuration. This asserts that that workflow works.
 	require := require.New(t)
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.StringFlag{FlagName: "token", FlagValue: "t1", Changed: true},
 		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: "e1", Changed: true},
 		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: "", Changed: false},
@@ -104,7 +107,8 @@ func TestGetCurrentTokenWithCLIOverrideWithoutSecretFile(t *testing.T) {
 	// When we refactored the token setting logic, we broke the workflow where zed is used without a saved
 	// context. This asserts that that workflow works.
 	require := require.New(t)
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.StringFlag{FlagName: "token", FlagValue: "t1", Changed: true},
 		zedtesting.StringFlag{FlagName: "endpoint", FlagValue: "e1", Changed: true},
 		zedtesting.StringFlag{FlagName: "certificate-path", FlagValue: "", Changed: false},
@@ -173,7 +177,8 @@ func TestRetries(t *testing.T) {
 
 	secure := true
 	retries := uint(2)
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.BoolFlag{FlagName: "skip-version-check", FlagValue: true, Changed: true},
 		zedtesting.UintFlag{FlagName: "max-retries", FlagValue: retries, Changed: true},
 		zedtesting.StringFlag{FlagName: "proxy", FlagValue: "", Changed: true},
@@ -217,7 +222,8 @@ func TestDoesNotRetry(t *testing.T) {
 
 	secure := true
 	retries := uint(2)
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.BoolFlag{FlagName: "skip-version-check", FlagValue: true, Changed: true},
 		zedtesting.UintFlag{FlagName: "max-retries", FlagValue: retries, Changed: true},
 		zedtesting.StringFlag{FlagName: "proxy", FlagValue: "", Changed: true},

--- a/internal/cmd/backup_test.go
+++ b/internal/cmd/backup_test.go
@@ -176,7 +176,8 @@ func TestBackupParseRelsCmdFunc(t *testing.T) {
 			tt := tt
 			t.Parallel()
 
-			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+				t,
 				zedtesting.StringToStringFlag{FlagName: "prefix-replacements"},
 				zedtesting.StringFlag{FlagName: "prefix-filter", FlagValue: tt.filter},
 				zedtesting.BoolFlag{FlagName: "rewrite-legacy"},
@@ -519,7 +520,8 @@ func validateBackupWithFunc(t testing.TB, backupFileName, schema string, token *
 }
 
 func TestBackupRestoreCmdFunc(t *testing.T) {
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.StringToStringFlag{FlagName: "prefix-replacements"},
 		zedtesting.StringFlag{FlagName: "prefix-filter", FlagValue: "test"},
 		zedtesting.BoolFlag{FlagName: "rewrite-legacy"},

--- a/internal/cmd/import_test.go
+++ b/internal/cmd/import_test.go
@@ -53,7 +53,8 @@ func TestImportCmd(t *testing.T) {
 	for testName, test := range testcases {
 		t.Run(testName, func(t *testing.T) {
 			require := require.New(t)
-			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+				t,
 				zedtesting.StringFlag{FlagName: "schema-definition-prefix", FlagValue: test.prefix},
 				zedtesting.BoolFlag{FlagName: "schema", FlagValue: test.importSchema},
 				zedtesting.BoolFlag{FlagName: "relationships", FlagValue: test.importRels},
@@ -104,7 +105,8 @@ func TestImportCmd(t *testing.T) {
 }
 
 func TestImportCmdRelationsOnly(t *testing.T) {
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.StringFlag{FlagName: "schema-definition-prefix"},
 		zedtesting.BoolFlag{FlagName: "schema", FlagValue: false},
 		zedtesting.BoolFlag{FlagName: "relationships", FlagValue: true},

--- a/internal/cmd/schema_test.go
+++ b/internal/cmd/schema_test.go
@@ -170,7 +170,8 @@ definition resource {
 	permission view = user
 }
 `
-			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+				t,
 				zedtesting.StringFlag{FlagName: "out", FlagValue: tc.outFile},
 			)
 			usedStdout, err := schemaCompileOuter(cmd, files)
@@ -438,7 +439,8 @@ definition resource {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+				t,
 				zedtesting.StringFlag{FlagName: "schema-definition-prefix", FlagValue: ""},
 				zedtesting.BoolFlag{FlagName: "json", FlagValue: true},
 			)

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -148,9 +148,10 @@ func validateCmdFunc(cmd *cobra.Command, filenames []string) (string, bool, erro
 		if fileType == decode.FileTypeZed {
 			contents, readErr := os.ReadFile(filename)
 			if readErr == nil && decode.LooksLikeYAMLValidationFile(string(contents)) {
-				fmt.Fprintf(toPrint, "%sfile %q has a .zed extension but appears to be a YAML validation file.\n"+
-					"  Rename the file to use a .yaml extension, or use --type yaml to override:\n"+
-					"    zed validate %s --type yaml\n\n",
+				fmt.Fprintf(
+					toPrint, "%sfile %q has a .zed extension but appears to be a YAML validation file.\n"+
+						"  Rename the file to use a .yaml extension, or use --type yaml to override:\n"+
+						"    zed validate %s --type yaml\n\n",
 					errorPrefix(), filename, filename,
 				)
 				shouldExit = true

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -47,7 +47,8 @@ func normalizeNewlines(s string) string {
 func TestValidatePreRun(t *testing.T) {
 	t.Parallel()
 
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.BoolFlag{FlagName: "force-color", FlagValue: false},
 		zedtesting.BoolFlag{FlagName: "fail-on-warn", FlagValue: false},
 		zedtesting.StringFlag{FlagName: "type", FlagValue: ""},
@@ -383,7 +384,8 @@ complete - 0 relationships loaded, 0 assertions run, 0 expected relations valida
 			t.Parallel()
 
 			require := require.New(t)
-			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+			cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+				t,
 				zedtesting.IntFlag{FlagName: "batch-size", FlagValue: 100},
 				zedtesting.IntFlag{FlagName: "workers", FlagValue: 1},
 				zedtesting.BoolFlag{FlagName: "fail-on-warn", FlagValue: false},
@@ -409,7 +411,8 @@ func TestFailOnWarn(t *testing.T) {
 	require := require.New(t)
 
 	// Run once with fail-on-warn set to false
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.BoolFlag{FlagName: "force-color", FlagValue: false},
 		zedtesting.IntFlag{FlagName: "batch-size", FlagValue: 100}, zedtesting.IntFlag{FlagName: "workers", FlagValue: 1},
 		zedtesting.BoolFlag{FlagName: "fail-on-warn", FlagValue: false},
@@ -420,7 +423,8 @@ func TestFailOnWarn(t *testing.T) {
 	require.False(shouldError, "validation pass should not fail without fail-on-warn")
 
 	// Run again with fail-on-warn set to true
-	cmd = zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd = zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.BoolFlag{FlagName: "force-color", FlagValue: false},
 		zedtesting.IntFlag{FlagName: "batch-size", FlagValue: 100},
 		zedtesting.IntFlag{FlagName: "workers", FlagValue: 1},

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -179,7 +179,8 @@ func TestVersionCommandWithUnavailableServer(t *testing.T) {
 	})
 
 	// Create command with all required flags
-	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(t,
+	cmd := zedtesting.CreateTestCobraCommandWithFlagValue(
+		t,
 		zedtesting.BoolFlag{FlagName: "include-remote-version", FlagValue: true},
 		zedtesting.BoolFlag{FlagName: "include-deps", FlagValue: false},
 		zedtesting.UintFlag{FlagName: "max-retries", FlagValue: 10},

--- a/internal/commands/permission.go
+++ b/internal/commands/permission.go
@@ -604,7 +604,8 @@ func lookupSubjectsCmdFunc(cmd *cobra.Command, args []string) error {
 
 				console.Println(string(prettyProto))
 			}
-			console.Printf("%s:%s%s\n",
+			console.Printf(
+				"%s:%s%s\n",
 				subjectType,
 				prettyLookupPermissionship(resp.Subject.SubjectObjectId, resp.Subject.Permissionship, resp.Subject.PartialCaveatInfo),
 				excludedSubjectsString(resp.ExcludedSubjects),

--- a/internal/commands/watch.go
+++ b/internal/commands/watch.go
@@ -164,7 +164,8 @@ func processResponse(resp *v1.WatchResponse) {
 			subjectRelation = " " + update.Relationship.Subject.OptionalRelation
 		}
 
-		console.Printf("%s:%s %s %s:%s%s\n",
+		console.Printf(
+			"%s:%s %s %s:%s%s\n",
 			update.Relationship.Resource.ObjectType,
 			update.Relationship.Resource.ObjectId,
 			update.Relationship.Relation,

--- a/internal/console/console.go
+++ b/internal/console/console.go
@@ -43,13 +43,15 @@ var Println = func(values ...any) {
 
 // CreateProgressBar creates a new progress bar with the given description and defaults adjusted to zed's UX experience
 func CreateProgressBar(description string) *progressbar.ProgressBar {
-	bar := progressbar.NewOptions(-1,
+	bar := progressbar.NewOptions(
+		-1,
 		progressbar.OptionSetWidth(10),
 		progressbar.OptionSetRenderBlankState(true),
 		progressbar.OptionSetVisibility(false),
 	)
 	if isatty.IsTerminal(os.Stderr.Fd()) {
-		bar = progressbar.NewOptions64(-1,
+		bar = progressbar.NewOptions64(
+			-1,
 			progressbar.OptionSetDescription(description),
 			progressbar.OptionSetWriter(os.Stderr),
 			progressbar.OptionSetWidth(10),

--- a/internal/mcp/mcp.go
+++ b/internal/mcp/mcp.go
@@ -133,9 +133,11 @@ func (smcp *spiceDBMCPServer) Run(portNumber int) error {
 	console.Printf("Setting up MCP tools and resources...\n")
 
 	// Add schema write tool
-	writeSchemaTools := mcp.NewTool("write_schema",
+	writeSchemaTools := mcp.NewTool(
+		"write_schema",
 		mcp.WithDescription("Write a SpiceDB schema definition"),
-		mcp.WithString("schema",
+		mcp.WithString(
+			"schema",
 			mcp.Required(),
 			mcp.Description("The schema definition text"),
 		),
@@ -143,9 +145,11 @@ func (smcp *spiceDBMCPServer) Run(portNumber int) error {
 	s.AddTool(writeSchemaTools, smcp.writeSchemaHandler)
 
 	// Add update relationships tool
-	updateRelationshipsTool := mcp.NewTool("update_relationships",
+	updateRelationshipsTool := mcp.NewTool(
+		"update_relationships",
 		mcp.WithDescription("Update relationships in SpiceDB with create, touch, and delete operations"),
-		mcp.WithArray("create",
+		mcp.WithArray(
+			"create",
 			mcp.Description("Array of relationships to create"),
 			mcp.Items(map[string]any{
 				"type": "object",
@@ -163,7 +167,8 @@ func (smcp *spiceDBMCPServer) Run(portNumber int) error {
 				"required": []string{"resource_type", "resource_id", "relation", "subject_type", "subject_id"},
 			}),
 		),
-		mcp.WithArray("touch",
+		mcp.WithArray(
+			"touch",
 			mcp.Description("Array of relationships to touch (update timestamp)"),
 			mcp.Items(map[string]any{
 				"type": "object",
@@ -181,7 +186,8 @@ func (smcp *spiceDBMCPServer) Run(portNumber int) error {
 				"required": []string{"resource_type", "resource_id", "relation", "subject_type", "subject_id"},
 			}),
 		),
-		mcp.WithArray("delete",
+		mcp.WithArray(
+			"delete",
 			mcp.Description("Array of relationships to delete"),
 			mcp.Items(map[string]any{
 				"type": "object",
@@ -203,112 +209,141 @@ func (smcp *spiceDBMCPServer) Run(portNumber int) error {
 	s.AddTool(updateRelationshipsTool, smcp.updateRelationshipsHandlerWrapper)
 
 	// Add delete relationships tool
-	deleteRelationshipsTool := mcp.NewTool("delete_relationships",
+	deleteRelationshipsTool := mcp.NewTool(
+		"delete_relationships",
 		mcp.WithDescription("Delete relationships matching a filter from SpiceDB"),
-		mcp.WithString("resource_type",
+		mcp.WithString(
+			"resource_type",
 			mcp.Description("Filter by resource type"),
 		),
-		mcp.WithString("resource_id",
+		mcp.WithString(
+			"resource_id",
 			mcp.Description("Filter by resource ID"),
 		),
-		mcp.WithString("relation",
+		mcp.WithString(
+			"relation",
 			mcp.Description("Filter by relation name"),
 		),
-		mcp.WithString("subject_type",
+		mcp.WithString(
+			"subject_type",
 			mcp.Description("Filter by subject type"),
 		),
-		mcp.WithString("subject_id",
+		mcp.WithString(
+			"subject_id",
 			mcp.Description("Filter by subject ID"),
 		),
-		mcp.WithString("optional_subject_relation",
+		mcp.WithString(
+			"optional_subject_relation",
 			mcp.Description("Filter by optional subject relation"),
 		),
 	)
 	s.AddTool(deleteRelationshipsTool, smcp.deleteRelationshipsHandlerWrapper)
 
 	// Add check permission tool
-	checkPermissionTool := mcp.NewTool("check_permission",
+	checkPermissionTool := mcp.NewTool(
+		"check_permission",
 		mcp.WithDescription("Check permission with full consistency and debug tracing"),
-		mcp.WithString("resource_type",
+		mcp.WithString(
+			"resource_type",
 			mcp.Required(),
 			mcp.Description("Resource type (e.g., 'document')"),
 		),
-		mcp.WithString("resource_id",
+		mcp.WithString(
+			"resource_id",
 			mcp.Required(),
 			mcp.Description("Resource ID (e.g., 'document1')"),
 		),
-		mcp.WithString("permission_or_relation",
+		mcp.WithString(
+			"permission_or_relation",
 			mcp.Required(),
 			mcp.Description("Permission or relation to check (e.g., 'view' or 'reader')"),
 		),
-		mcp.WithString("subject_type",
+		mcp.WithString(
+			"subject_type",
 			mcp.Required(),
 			mcp.Description("Subject type (e.g., 'user')"),
 		),
-		mcp.WithString("subject_id",
+		mcp.WithString(
+			"subject_id",
 			mcp.Required(),
 			mcp.Description("Subject ID (e.g., 'user1')"),
 		),
-		mcp.WithString("optional_subject_relation",
+		mcp.WithString(
+			"optional_subject_relation",
 			mcp.Description("Optional subject relation"),
 		),
-		mcp.WithString("optional_caveat_context_json",
+		mcp.WithString(
+			"optional_caveat_context_json",
 			mcp.Description("Optional caveat context, as a JSON string"),
 		),
 	)
 	s.AddTool(checkPermissionTool, smcp.checkPermissionHandler)
 
 	// Add lookup resources tool
-	lookupResourcesTool := mcp.NewTool("lookup_resources",
+	lookupResourcesTool := mcp.NewTool(
+		"lookup_resources",
 		mcp.WithDescription("Lookup resources that a subject has permission to access"),
-		mcp.WithString("resource_object_type",
+		mcp.WithString(
+			"resource_object_type",
 			mcp.Required(),
 			mcp.Description("Type of resources to lookup (e.g., 'document')"),
 		),
-		mcp.WithString("permission",
+		mcp.WithString(
+			"permission",
 			mcp.Required(),
 			mcp.Description("Permission to check (e.g., 'view')"),
 		),
-		mcp.WithString("subject_type",
+		mcp.WithString(
+			"subject_type",
 			mcp.Required(),
 			mcp.Description("Subject type (e.g., 'user')"),
 		),
-		mcp.WithString("subject_id",
+		mcp.WithString(
+			"subject_id",
 			mcp.Required(),
 			mcp.Description("Subject ID (e.g., 'user1')"),
 		),
-		mcp.WithString("optional_subject_relation",
+		mcp.WithString(
+			"optional_subject_relation",
 			mcp.Description("Optional subject relation"),
 		),
-		mcp.WithString("optional_caveat_context_json",
+		mcp.WithString(
+			"optional_caveat_context_json",
 			mcp.Description("Optional caveat context, as a JSON string"),
 		),
 	)
 	s.AddTool(lookupResourcesTool, smcp.lookupResourcesHandler)
 
 	// Add lookup subjects tool
-	lookupSubjectsTool := mcp.NewTool("lookup_subjects",
+	lookupSubjectsTool := mcp.NewTool(
+		"lookup_subjects",
 		mcp.WithDescription("Lookup subjects that have permission to access a resource"),
-		mcp.WithString("subject_object_type",
+		mcp.WithString(
+			"subject_object_type",
 			mcp.Required(),
 			mcp.Description("Type of subjects to lookup (e.g., 'user')"),
 		),
-		mcp.WithString("permission",
+		mcp.WithString(
+			"permission",
 			mcp.Required(),
 			mcp.Description("Permission to check (e.g., 'view')"),
 		),
-		mcp.WithString("resource_type",
+		mcp.WithString(
+			"resource_type",
 			mcp.Required(),
 			mcp.Description("Resource type (e.g., 'document')"),
 		),
-		mcp.WithString("resource_id",
+		mcp.WithString(
+			"resource_id",
 			mcp.Required(),
 			mcp.Description("Resource ID (e.g., 'document1')"),
 		),
-		mcp.WithString("optional_resource_relation",
+		mcp.WithString(
+			"optional_resource_relation",
 			mcp.Description("Optional resource relation"),
 		),
-		mcp.WithString("optional_caveat_context_json",
+		mcp.WithString(
+			"optional_caveat_context_json",
 			mcp.Description("Optional caveat context, as a JSON string"),
 		),
 	)
@@ -1106,7 +1141,8 @@ func (smcp *spiceDBMCPServer) getValidationFileHandler(ctx context.Context, requ
 }
 
 func newSpiceDBServer(ctx context.Context) (server.RunnableServer, error) {
-	ds, err := datastore.NewDatastore(ctx,
+	ds, err := datastore.NewDatastore(
+		ctx,
 		datastore.DefaultDatastoreConfig().ToOption(),
 		datastore.WithRequestHedgingEnabled(false),
 	)

--- a/internal/printers/table.go
+++ b/internal/printers/table.go
@@ -10,7 +10,8 @@ import (
 
 // PrintTable writes an terminal-friendly table of the values to the target.
 func PrintTable(target io.Writer, headers []string, rows [][]string) {
-	table := tablewriter.NewTable(target,
+	table := tablewriter.NewTable(
+		target,
 		tablewriter.WithRenderer(renderer.NewBlueprint()),
 		tablewriter.WithRowAutoWrap(tw.WrapNone),
 		tablewriter.WithHeaderAutoFormat(tw.On),

--- a/internal/zedtesting/test_helpers.go
+++ b/internal/zedtesting/test_helpers.go
@@ -34,7 +34,8 @@ func ClientFromConn(conn *grpc.ClientConn) func(_ *cobra.Command) (client.Client
 func NewTestServer(ctx context.Context, t *testing.T) server.RunnableServer {
 	t.Helper()
 
-	ds, err := datastore.NewDatastore(ctx,
+	ds, err := datastore.NewDatastore(
+		ctx,
 		datastore.DefaultDatastoreConfig().ToOption(),
 		datastore.WithRequestHedgingEnabled(false),
 	)

--- a/pkg/backupformat/rewriter_test.go
+++ b/pkg/backupformat/rewriter_test.go
@@ -365,7 +365,8 @@ func TestChainRewriter(t *testing.T) {
 			},
 		}
 
-		rels := toV1Rels(t,
+		rels := toV1Rels(
+			t,
 			"test/resource:1#reader@test/user:1",
 			"other/resource:2#reader@other/user:2",
 		)


### PR DESCRIPTION
Restores gofumpt-clean state across the tree after a gofumpt release introduced new rules around the placement of the first argument of multi-line function calls. Pure formatting, no behavior changes.