### PR TITLE
feat: package shell completions into DEB, RPM, and APK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 temp/
 docs/merged.md
+completions/
 
 # Local-only files
 go.work

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,9 +2,9 @@
 version: 2
 before:
   hooks:
-    - sh -c "mkdir -p completions && go run ./cmd/zed completion bash > ./completions/zed.bash"
-    - sh -c "go run ./cmd/zed completion zsh > ./completions/zed.zsh"
-    - sh -c "go run ./cmd/zed completion fish > ./completions/zed.fish"
+    - 'sh -c "mkdir -p completions && go run ./cmd/zed completion bash > ./completions/zed.bash"'
+    - 'sh -c "go run ./cmd/zed completion zsh > ./completions/zed.zsh"'
+    - 'sh -c "go run ./cmd/zed completion fish > ./completions/zed.fish"'
 builds:
   - id: "linux-amd64-gnu"
     goos: ["linux"]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,8 @@
 ---
 version: 2
+before:
+  hooks:
+    - "go run mage.go gen:completions"
 builds:
   - id: "linux-amd64-gnu"
     goos: ["linux"]
@@ -108,6 +111,19 @@ nfpms:
     epoch: &epoch "0"
     ids: ["linux-amd64-gnu", "linux-arm64-gnu"]
     formats: ["deb", "rpm"]
+    contents: &nfpm_contents
+      - src: "./completions/zed.bash"
+        dst: "/usr/share/bash-completion/completions/zed"
+        file_info:
+          mode: 0644
+      - src: "./completions/zed.fish"
+        dst: "/usr/share/fish/vendor_completions.d/zed.fish"
+        file_info:
+          mode: 0644
+      - src: "./completions/zed.zsh"
+        dst: "/usr/share/zsh/site-functions/_zed"
+        file_info:
+          mode: 0644
   - id: "musl"
     vendor: *vendor
     homepage: *homepage
@@ -117,6 +133,7 @@ nfpms:
     epoch: *epoch
     ids: ["linux-amd64-musl", "linux-arm64-musl"]
     formats: ["apk"]
+    contents: *nfpm_contents
 
 furies:
   - account: "authzed"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,9 @@
 version: 2
 before:
   hooks:
-    - "go run mage.go gen:completions"
+    - sh -c "mkdir -p completions && go run ./cmd/zed completion bash > ./completions/zed.bash"
+    - sh -c "go run ./cmd/zed completion zsh > ./completions/zed.zsh"
+    - sh -c "go run ./cmd/zed completion fish > ./completions/zed.fish"
 builds:
   - id: "linux-amd64-gnu"
     goos: ["linux"]

--- a/magefiles/gen.go
+++ b/magefiles/gen.go
@@ -4,14 +4,11 @@
 package main
 
 import (
-	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
-	"github.com/spf13/cobra"
 
 	"github.com/authzed/zed/internal/cmd"
 )
@@ -49,40 +46,4 @@ func (g Gen) DocsForPublish() error {
 	}
 
 	return sh.RunV("bash", "-c", "cat docs/getting-started.md <(echo -e '\\n') docs/zed.md > docs/merged.md")
-}
-
-// Completions Generate shell completion scripts for bash, zsh, and fish
-func (g Gen) Completions() error {
-	targetDir := "completions"
-
-	if err := os.MkdirAll(targetDir, 0o755); err != nil {
-		return err
-	}
-
-	rootCmd := cmd.InitialiseRootCmd(cobrazerolog.New())
-
-	generators := []struct {
-		shell    string
-		generate func(*cobra.Command, io.Writer) error
-	}{
-		{"bash", func(c *cobra.Command, w io.Writer) error { return c.GenBashCompletionV2(w, true) }},
-		{"zsh", func(c *cobra.Command, w io.Writer) error { return c.GenZshCompletion(w) }},
-		{"fish", func(c *cobra.Command, w io.Writer) error { return c.GenFishCompletion(w, true) }},
-	}
-
-	for _, gen := range generators {
-		path := filepath.Join(targetDir, "zed."+gen.shell)
-		f, err := os.Create(path)
-		if err != nil {
-			return err
-		}
-		if err := gen.generate(rootCmd, f); err != nil {
-			f.Close()
-			return err
-		}
-		if err := f.Close(); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/magefiles/gen.go
+++ b/magefiles/gen.go
@@ -4,11 +4,14 @@
 package main
 
 import (
+	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/jzelinskie/cobrautil/v2/cobrazerolog"
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
+	"github.com/spf13/cobra"
 
 	"github.com/authzed/zed/internal/cmd"
 )
@@ -46,4 +49,40 @@ func (g Gen) DocsForPublish() error {
 	}
 
 	return sh.RunV("bash", "-c", "cat docs/getting-started.md <(echo -e '\\n') docs/zed.md > docs/merged.md")
+}
+
+// Completions Generate shell completion scripts for bash, zsh, and fish
+func (g Gen) Completions() error {
+	targetDir := "completions"
+
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return err
+	}
+
+	rootCmd := cmd.InitialiseRootCmd(cobrazerolog.New())
+
+	generators := []struct {
+		shell    string
+		generate func(*cobra.Command, io.Writer) error
+	}{
+		{"bash", func(c *cobra.Command, w io.Writer) error { return c.GenBashCompletionV2(w, true) }},
+		{"zsh", func(c *cobra.Command, w io.Writer) error { return c.GenZshCompletion(w) }},
+		{"fish", func(c *cobra.Command, w io.Writer) error { return c.GenFishCompletion(w, true) }},
+	}
+
+	for _, gen := range generators {
+		path := filepath.Join(targetDir, "zed."+gen.shell)
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		if err := gen.generate(rootCmd, f); err != nil {
+			f.Close()
+			return err
+		}
+		if err := f.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Adds a `Gen.Completions` mage target that generates bash/zsh/fish completion scripts via Cobra's built-in generators, and wires goreleaser to produce them before each build and install them into the standard system paths for DEB, RPM, and APK packages.

Fixes #345