### PR TITLE
fix(cli): support '-' for stdin in backup restore

### DIFF
--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -474,7 +474,7 @@ func isCanceled(err error) bool {
 }
 
 func openRestoreFile(filename string) (*os.File, int64, error) {
-	if filename == "" {
+	if filename == "" || filename == "-" {
 		log.Trace().Str("filename", "(stdin)").Send()
 		return os.Stdin, -1, nil
 	}

--- a/internal/cmd/backup_test.go
+++ b/internal/cmd/backup_test.go
@@ -590,6 +590,88 @@ func TestBackupRestoreCmdFunc(t *testing.T) {
 	require.Equal(t, "test/resource:1#reader@test/user:1", tuple.MustV1StringRelationship(rrResp.Relationship))
 }
 
+func TestOpenRestoreFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "backup-*.zed")
+	if err != nil {
+		t.Fatalf("failed to create temp file for testing: %v", err)
+	}
+
+	dummyContent := []byte("dummy-data")
+	if _, err := tmpFile.Write(dummyContent); err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	err = tmpFile.Close()
+	if err != nil {
+		t.Fatalf("failed to close file: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		filename     string
+		expectError  bool
+		expectedSize int64
+	}{
+		{
+			name:         "empty filename defaults to stdin",
+			filename:     "",
+			expectError:  false,
+			expectedSize: -1,
+		},
+		{
+			name:         "dash filename defaults to stdin",
+			filename:     "-",
+			expectError:  false,
+			expectedSize: -1,
+		},
+		{
+			name:         "valid file returns file descriptor and correct size",
+			filename:     tmpFile.Name(),
+			expectError:  false,
+			expectedSize: int64(len(dummyContent)),
+		},
+		{
+			name:         "invalid file returns error",
+			filename:     "nonexistent_file.zed",
+			expectError:  true,
+			expectedSize: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, size, err := openRestoreFile(tt.filename)
+
+			if f != nil && f != os.Stdin {
+				defer func(f *os.File) {
+					err := f.Close()
+					if err != nil {
+						t.Fatalf("failed to close file: %v", err)
+					}
+				}(f)
+			}
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if size != tt.expectedSize {
+					t.Errorf("expected size %d, got %d", tt.expectedSize, size)
+				}
+				if tt.filename == "" || tt.filename == "-" {
+					if f != os.Stdin {
+						t.Errorf("expected os.Stdin")
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestPrintBackupFileLocation(t *testing.T) {
 	previous := console.Errorf
 	t.Cleanup(func() {


### PR DESCRIPTION
<!--
If your PR is not ready to be reviewed or merged, please submit it as a "draft".
-->

## Description

`zed backup restore -` currently fails with `unable to stat restore file: stat -: no such file or directory` because the code attempts to call `os.Stat()` on the literal `"-"` string.

This PR adds standard Unix `-` shorthand support for stdin, aligning the behavior with `zed backup create -` (implemented in #688). `openRestoreFile` now treats `filename == "-"` identically to `filename == ""`, returning `os.Stdin` directly.

## Testing

* Added table-driven unit test `TestOpenRestoreFile` in `backup_test.go` covering `""`, `-`, valid file paths, and invalid file errors
* Manually verified via: `cat backup.zed | zed backup restore -`

## References

* Closes #698
* Relates to #688