### PR TITLE
fix: use placeholders for the remote URL examples in validate/import help

### DIFF
--- a/docs/zed.md
+++ b/docs/zed.md
@@ -475,13 +475,13 @@ zed import <url> [flags]
 ```
 
 	From a gist:
-		zed import https://gist.github.com/ecordell/8e3b613a677e3c844742cf24421c08b6
+		zed import https://gist.github.com/YOUR_USERNAME/YOUR_GIST_ID
 
 	From a playground link:
-		zed import https://play.authzed.com/s/iksdFvCtvnkR/schema
+		zed import https://play.authzed.com/s/YOUR_SHARE_ID/schema
 
 	From pastebin:
-		zed import https://pastebin.com/8qU45rVK
+		zed import https://pastebin.com/YOUR_PASTE_ID
 
 	From a devtools instance:
 		zed import https://localhost:8443/download
@@ -1416,13 +1416,13 @@ zed validate <validation_files_or_schema_files> [flags]
 		zed validate authzed-x7izWU8_2Gw3.yaml
 
 	From a gist:
-		zed validate https://gist.github.com/ecordell/8e3b613a677e3c844742cf24421c08b6
+		zed validate https://gist.github.com/YOUR_USERNAME/YOUR_GIST_ID
 
 	From a playground link:
-		zed validate https://play.authzed.com/s/iksdFvCtvnkR/schema
+		zed validate https://play.authzed.com/s/YOUR_SHARE_ID/schema
 
 	From pastebin:
-		zed validate https://pastebin.com/8qU45rVK
+		zed validate https://pastebin.com/YOUR_PASTE_ID
 ```
 
 ### Options

--- a/internal/cmd/import.go
+++ b/internal/cmd/import.go
@@ -25,13 +25,13 @@ func registerImportCmd(rootCmd *cobra.Command) {
 		Short: "Imports schema and relationships from a file or url",
 		Example: `
 	From a gist:
-		zed import https://gist.github.com/ecordell/8e3b613a677e3c844742cf24421c08b6
+		zed import https://gist.github.com/YOUR_USERNAME/YOUR_GIST_ID
 
 	From a playground link:
-		zed import https://play.authzed.com/s/iksdFvCtvnkR/schema
+		zed import https://play.authzed.com/s/YOUR_SHARE_ID/schema
 
 	From pastebin:
-		zed import https://pastebin.com/8qU45rVK
+		zed import https://pastebin.com/YOUR_PASTE_ID
 
 	From a devtools instance:
 		zed import https://localhost:8443/download

--- a/internal/cmd/validate.go
+++ b/internal/cmd/validate.go
@@ -55,13 +55,13 @@ func registerValidateCmd(cmd *cobra.Command) {
 		zed validate authzed-x7izWU8_2Gw3.yaml
 
 	From a gist:
-		zed validate https://gist.github.com/ecordell/8e3b613a677e3c844742cf24421c08b6
+		zed validate https://gist.github.com/YOUR_USERNAME/YOUR_GIST_ID
 
 	From a playground link:
-		zed validate https://play.authzed.com/s/iksdFvCtvnkR/schema
+		zed validate https://play.authzed.com/s/YOUR_SHARE_ID/schema
 
 	From pastebin:
-		zed validate https://pastebin.com/8qU45rVK`,
+		zed validate https://pastebin.com/YOUR_PASTE_ID`,
 		Args:              commands.ValidationWrapper(cobra.MinimumNArgs(1)),
 		ValidArgsFunction: commands.FileExtensionCompletions("zed", "yaml", "yml", "zaml"),
 		PreRunE:           validatePreRunE,

--- a/internal/cmd/validate_test.go
+++ b/internal/cmd/validate_test.go
@@ -215,12 +215,6 @@ complete - 0 relationships loaded, 0 assertions run, 0 expected relations valida
 				" 10 |   }\n" +
 				" 11 | \n\n\n",
 		},
-		// TODO: https://github.com/authzed/zed/issues/487
-		// `url_passes`: {
-		//	files: []string{
-		//		"https://play.authzed.com/s/iksdFvCtvnkR/schema",
-		//	},
-		// },
 		`composable_schema_passes`: {
 			files: []string{
 				filepath.Join("validate-test", "composable-schema-root.zed"),


### PR DESCRIPTION
The help for `zed validate` and `zed import` had a hardcoded playground link in the examples, and that share has gone stale, so if you copy paste it you just get a parse error. The gist and pastebin ones next to it will probably rot the same way eventually.

The feature itself is fine btw, the playground URL handling still works and is tested in decoder_test.go, it's only the baked-in link that died. So instead of removing the example I just swapped all three over to placeholders (YOUR_SHARE_ID and so on) so they still show up in --help but can't go stale.

Also dropped an old disabled url_passes test that pointed at the same dead link (it's already covered in decoder_test) and regenerated docs/zed.md.

Fixes #487