### PR TITLE
build: fix brew release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: "Install cross-compilers"
         run: |
           brew tap messense/macos-cross-toolchains
+          brew trust messense/macos-cross-toolchains
           brew install x86_64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-gnu aarch64-unknown-linux-musl mingw-w64
           echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       - uses: "authzed/actions/setup-go@main"


### PR DESCRIPTION
Should fix 

https://github.com/authzed/zed/actions/runs/29766134174/job/88432711801

> Error: Refusing to load formula messense/macos-cross-toolchains/x86_64-unknown-linux-gnu from untrusted tap messense/macos-cross-toolchains.
> Run `brew trust --formula messense/macos-cross-toolchains/x86_64-unknown-linux-gnu` or `brew trust messense/macos-cross-toolchains` to trust it.
